### PR TITLE
chore: deliberate lint error to verify CI blocking

### DIFF
--- a/packages/account/src/index.ts
+++ b/packages/account/src/index.ts
@@ -2,3 +2,6 @@ export type { AccountStatus, ApplicationUser, AuthIdentity } from "./account.js"
 export { AccountStatusSchema, ApplicationUserSchema, AuthIdentitySchema } from "./account.js";
 
 export type { AuthContext } from "./auth.js";
+
+// deliberate lint error for CI verification
+var badVariable = "this will fail lint";


### PR DESCRIPTION
This PR intentionally introduces a lint error to verify branch protection blocks merging.