### PR TITLE
fix(cd): add terraform to CD build job so infra tests pass

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
+      - uses: hashicorp/setup-terraform@v3
       - uses: actions/cache@v4
         with:
           path: ~/.local/share/pnpm/store


### PR DESCRIPTION
The CD `build` job runs `pnpm test` which includes `terraform-plan.test.ts`. Terraform wasn't installed in that job, causing `spawnSync terraform ENOENT` failures.

Adds `hashicorp/setup-terraform@v3` to the CD build job, matching what was already done for the CI test job.