### PR TITLE
fix(cd): build workspace deps before packaging

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,6 +47,7 @@ jobs:
           key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: pnpm-store-
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - run: pnpm --filter @petroglyph/api package
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The CD `package` job runs `pnpm --filter @petroglyph/api package` which internally calls `tsc` on the API. This fails with `Cannot find module '@petroglyph/core'` because `@petroglyph/core`'s `dist/` doesn't exist on fresh runners.

Adds `pnpm build` before packaging to ensure all workspace packages are built first.