### PR TITLE
fix(ci,cd): share deps and dist across jobs via cache

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,9 +23,17 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
       - uses: actions/cache@v4
         with:
-          path: ~/.local/share/pnpm/store
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-store-
+          path: |
+            ~/.local/share/pnpm/store
+            node_modules
+            packages/*/node_modules
+          key: deps-${{ hashFiles('pnpm-lock.yaml') }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            packages/*/dist
+            packages/*/*.tsbuildinfo
+          key: dist-${{ github.sha }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test
@@ -43,11 +51,17 @@ jobs:
           node-version: "24"
       - uses: actions/cache@v4
         with:
-          path: ~/.local/share/pnpm/store
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-store-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+          path: |
+            ~/.local/share/pnpm/store
+            node_modules
+            packages/*/node_modules
+          key: deps-${{ hashFiles('pnpm-lock.yaml') }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            packages/*/dist
+            packages/*/*.tsbuildinfo
+          key: dist-${{ github.sha }}
       - run: pnpm --filter @petroglyph/api package
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,6 +47,7 @@ jobs:
           key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: pnpm-store-
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - run: pnpm --filter @petroglyph/api package
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,11 @@ jobs:
           node-version: "24"
       - uses: actions/cache@v4
         with:
-          path: ~/.local/share/pnpm/store
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-store-
+          path: |
+            ~/.local/share/pnpm/store
+            node_modules
+            packages/*/node_modules
+          key: deps-${{ hashFiles('pnpm-lock.yaml') }}
       - run: pnpm install --frozen-lockfile
 
   build:
@@ -39,14 +41,21 @@ jobs:
           node-version: "24"
       - uses: actions/cache@v4
         with:
-          path: ~/.local/share/pnpm/store
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-store-
-      - run: pnpm install --frozen-lockfile
+          path: |
+            ~/.local/share/pnpm/store
+            node_modules
+            packages/*/node_modules
+          key: deps-${{ hashFiles('pnpm-lock.yaml') }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            packages/*/dist
+            packages/*/*.tsbuildinfo
+          key: dist-${{ github.sha }}
       - run: pnpm build
 
   lint:
-    needs: [install]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,15 +67,21 @@ jobs:
           node-version: "24"
       - uses: actions/cache@v4
         with:
-          path: ~/.local/share/pnpm/store
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-store-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+          path: |
+            ~/.local/share/pnpm/store
+            node_modules
+            packages/*/node_modules
+          key: deps-${{ hashFiles('pnpm-lock.yaml') }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            packages/*/dist
+            packages/*/*.tsbuildinfo
+          key: dist-${{ github.sha }}
       - run: pnpm lint
 
   typecheck:
-    needs: [install]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -78,15 +93,21 @@ jobs:
           node-version: "24"
       - uses: actions/cache@v4
         with:
-          path: ~/.local/share/pnpm/store
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-store-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+          path: |
+            ~/.local/share/pnpm/store
+            node_modules
+            packages/*/node_modules
+          key: deps-${{ hashFiles('pnpm-lock.yaml') }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            packages/*/dist
+            packages/*/*.tsbuildinfo
+          key: dist-${{ github.sha }}
       - run: pnpm typecheck
 
   test:
-    needs: [install]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,11 +120,17 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
       - uses: actions/cache@v4
         with:
-          path: ~/.local/share/pnpm/store
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-store-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+          path: |
+            ~/.local/share/pnpm/store
+            node_modules
+            packages/*/node_modules
+          key: deps-${{ hashFiles('pnpm-lock.yaml') }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            packages/*/dist
+            packages/*/*.tsbuildinfo
+          key: dist-${{ github.sha }}
       - run: pnpm test
 
   format-check:
@@ -119,8 +146,9 @@ jobs:
           node-version: "24"
       - uses: actions/cache@v4
         with:
-          path: ~/.local/share/pnpm/store
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-store-
-      - run: pnpm install --frozen-lockfile
+          path: |
+            ~/.local/share/pnpm/store
+            node_modules
+            packages/*/node_modules
+          key: deps-${{ hashFiles('pnpm-lock.yaml') }}
       - run: pnpm format:check


### PR DESCRIPTION
## Problem

Each job was reinstalling deps and rebuilding from scratch, causing `@petroglyph/core` dist files to be missing in downstream jobs.

## Solution

Two shared caches:
- **deps cache** (`~/.local/share/pnpm/store` + `node_modules` + `packages/*/node_modules`): keyed on `pnpm-lock.yaml` hash
- **dist cache** (`packages/*/dist` + `*.tsbuildinfo`): keyed on commit SHA

### CI
- `install` → populates deps cache
- `build` → restores deps cache, populates dist cache
- `lint`/`typecheck`/`test` → `needs: [build]`, restores both caches
- `format-check` → `needs: [install]`, restores deps cache only

### CD
- `build` → populates both caches (also runs tests)
- `package` → restores both caches, no redundant install/build