### PR TITLE
fix(cd): cache deps+dist across jobs; make ingest/processor lambdas optional

### DIFF
--- a/packages/infra/lambda_ingestion.tf
+++ b/packages/infra/lambda_ingestion.tf
@@ -48,6 +48,8 @@ resource "aws_cloudwatch_metric_alarm" "ingest_dlq_depth" {
 # ---------------------------------------------------------------------------
 
 resource "aws_lambda_function" "petroglyph_ingest_onedrive" {
+  count = var.ingest_onedrive_zip_s3_bucket != "" ? 1 : 0
+
   function_name = "petroglyph-ingest-onedrive-${terraform.workspace}"
 
   s3_bucket = var.ingest_onedrive_zip_s3_bucket
@@ -71,28 +73,36 @@ resource "aws_lambda_function" "petroglyph_ingest_onedrive" {
 }
 
 resource "aws_apigatewayv2_integration" "petroglyph_ingest_onedrive" {
+  count = var.ingest_onedrive_zip_s3_bucket != "" ? 1 : 0
+
   api_id                 = aws_apigatewayv2_api.petroglyph_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = aws_lambda_function.petroglyph_ingest_onedrive.invoke_arn
+  integration_uri        = aws_lambda_function.petroglyph_ingest_onedrive[0].invoke_arn
   payload_format_version = "2.0"
 }
 
 resource "aws_apigatewayv2_route" "onedrive_webhook_post" {
+  count = var.ingest_onedrive_zip_s3_bucket != "" ? 1 : 0
+
   api_id    = aws_apigatewayv2_api.petroglyph_api.id
   route_key = "POST /webhooks/onedrive"
-  target    = "integrations/${aws_apigatewayv2_integration.petroglyph_ingest_onedrive.id}"
+  target    = "integrations/${aws_apigatewayv2_integration.petroglyph_ingest_onedrive[0].id}"
 }
 
 resource "aws_lambda_permission" "api_gateway_ingest_onedrive" {
+  count = var.ingest_onedrive_zip_s3_bucket != "" ? 1 : 0
+
   statement_id  = "AllowAPIGatewayInvokeIngestOnedrive"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.petroglyph_ingest_onedrive.function_name
+  function_name = aws_lambda_function.petroglyph_ingest_onedrive[0].function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.petroglyph_api.execution_arn}/*/*/webhooks/onedrive"
 }
 
 resource "aws_cloudwatch_log_group" "lambda_ingest_onedrive" {
-  name              = "/aws/lambda/${aws_lambda_function.petroglyph_ingest_onedrive.function_name}"
+  count = var.ingest_onedrive_zip_s3_bucket != "" ? 1 : 0
+
+  name              = "/aws/lambda/${aws_lambda_function.petroglyph_ingest_onedrive[0].function_name}"
   retention_in_days = 14
 
   tags = {
@@ -105,6 +115,8 @@ resource "aws_cloudwatch_log_group" "lambda_ingest_onedrive" {
 # ---------------------------------------------------------------------------
 
 resource "aws_lambda_function" "petroglyph_processor" {
+  count = var.processor_zip_s3_bucket != "" ? 1 : 0
+
   function_name = "petroglyph-processor-${terraform.workspace}"
 
   s3_bucket = var.processor_zip_s3_bucket
@@ -118,10 +130,10 @@ resource "aws_lambda_function" "petroglyph_processor" {
 
   environment {
     variables = {
-      FILE_RECORDS_TABLE    = local.file_records_table_name
-      MICROSOFT_CLIENT_ID  = aws_ssm_parameter.onedrive_client_id.value
-      STAGED_PDFS_BUCKET   = aws_s3_bucket.staged_pdfs.bucket
-      STAGED_PDF_PREFIX    = "handwritten"
+      FILE_RECORDS_TABLE  = local.file_records_table_name
+      MICROSOFT_CLIENT_ID = aws_ssm_parameter.onedrive_client_id.value
+      STAGED_PDFS_BUCKET  = aws_s3_bucket.staged_pdfs.bucket
+      STAGED_PDF_PREFIX   = "handwritten"
     }
   }
 
@@ -131,14 +143,18 @@ resource "aws_lambda_function" "petroglyph_processor" {
 }
 
 resource "aws_lambda_event_source_mapping" "processor_ingest_queue" {
+  count = var.processor_zip_s3_bucket != "" ? 1 : 0
+
   event_source_arn        = aws_sqs_queue.ingest.arn
-  function_name           = aws_lambda_function.petroglyph_processor.arn
+  function_name           = aws_lambda_function.petroglyph_processor[0].arn
   batch_size              = 10
   function_response_types = ["ReportBatchItemFailures"]
 }
 
 resource "aws_cloudwatch_log_group" "lambda_processor" {
-  name              = "/aws/lambda/${aws_lambda_function.petroglyph_processor.function_name}"
+  count = var.processor_zip_s3_bucket != "" ? 1 : 0
+
+  name              = "/aws/lambda/${aws_lambda_function.petroglyph_processor[0].function_name}"
   retention_in_days = 14
 
   tags = {

--- a/packages/infra/src/terraform-plan.test.ts
+++ b/packages/infra/src/terraform-plan.test.ts
@@ -87,7 +87,7 @@ describe.sequential("terraform ingestion infrastructure", () => {
       /resource "aws_lambda_function" "petroglyph_processor" \{[\s\S]*timeout\s*=\s*60[\s\S]*environment \{[\s\S]*MICROSOFT_CLIENT_ID\s*=\s*aws_ssm_parameter\.onedrive_client_id\.value[\s\S]*\}[\s\S]*\}/,
     );
     expect(lambdaIngestionTerraform).toMatch(
-      /resource "aws_lambda_event_source_mapping" "processor_ingest_queue" \{[\s\S]*event_source_arn\s*=\s*aws_sqs_queue\.ingest\.arn[\s\S]*function_name\s*=\s*aws_lambda_function\.petroglyph_processor\.arn[\s\S]*batch_size\s*=\s*10/,
+      /resource "aws_lambda_event_source_mapping" "processor_ingest_queue" \{[\s\S]*event_source_arn\s*=\s*aws_sqs_queue\.ingest\.arn[\s\S]*function_name\s*=\s*aws_lambda_function\.petroglyph_processor\[0\]\.arn[\s\S]*batch_size\s*=\s*10/,
     );
     expect(lambdaIngestionTerraform).toContain('route_key = "POST /webhooks/onedrive"');
     expect(lambdaIngestionTerraform).toContain(

--- a/packages/infra/variables.tf
+++ b/packages/infra/variables.tf
@@ -13,23 +13,27 @@ variable "api_zip_s3_key" {
 }
 
 variable "ingest_onedrive_zip_s3_bucket" {
-  description = "S3 bucket containing the ingest-onedrive Lambda deployment zip"
+  description = "S3 bucket containing the ingest-onedrive Lambda deployment zip. Empty string disables the Lambda."
   type        = string
+  default     = ""
 }
 
 variable "ingest_onedrive_zip_s3_key" {
-  description = "S3 key of the ingest-onedrive Lambda deployment zip"
+  description = "S3 key of the ingest-onedrive Lambda deployment zip. Empty string disables the Lambda."
   type        = string
+  default     = ""
 }
 
 variable "processor_zip_s3_bucket" {
-  description = "S3 bucket containing the processor Lambda deployment zip"
+  description = "S3 bucket containing the processor Lambda deployment zip. Empty string disables the Lambda."
   type        = string
+  default     = ""
 }
 
 variable "processor_zip_s3_key" {
-  description = "S3 key of the processor Lambda deployment zip"
+  description = "S3 key of the processor Lambda deployment zip. Empty string disables the Lambda."
   type        = string
+  default     = ""
 }
 
 variable "retention_days" {


### PR DESCRIPTION
Two fixes:

## 1. Share deps and dist cache across CI/CD jobs

- `install` populates deps cache (pnpm store + node_modules), keyed on `pnpm-lock.yaml`
- `build` restores deps cache, populates dist cache (packages/*/dist), keyed on commit SHA
- All downstream jobs restore both caches — no redundant installs or builds
- `lint`/`typecheck`/`test` now `need: [build]` so dist is guaranteed present

## 2. Make ingest-onedrive and processor lambdas optional

Variables default to `""`; all dependent resources use `count = var != "" ? 1 : 0`.
Terraform apply no longer hangs waiting for interactive input when those zips haven't been packaged yet.