### PR TITLE
fix(api): bundle with esbuild to include transitive dependencies

### DIFF
--- a/packages/api/esbuild.config.mjs
+++ b/packages/api/esbuild.config.mjs
@@ -1,0 +1,11 @@
+import esbuild from "esbuild";
+
+await esbuild.build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  format: "esm",
+  outfile: "dist/index.js",
+  platform: "node",
+  sourcemap: false,
+  logLevel: "info",
+});

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "devDependencies": {
     "@types/aws-lambda": "^8.10.145",
-    "@types/node": "^25.5.2"
+    "@types/node": "^25.5.2",
+    "esbuild": "^0.28.0"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "node esbuild.config.mjs",
     "package": "bash scripts/package.sh",
     "dev": "tsc -p tsconfig.build.json --watch",
     "lint": "eslint .",

--- a/packages/api/scripts/package.sh
+++ b/packages/api/scripts/package.sh
@@ -3,38 +3,19 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 API_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-STAGING_DIR="$API_DIR/.lambda-staging"
 OUTPUT="$API_DIR/lambda.zip"
 
 echo "Building @petroglyph/api..."
 pnpm build
 
-echo "Staging deployment artifact..."
-rm -rf "$STAGING_DIR"
-mkdir -p "$STAGING_DIR"
-
-cp -r "$API_DIR/dist" "$STAGING_DIR/dist"
-cp "$API_DIR/package.json" "$STAGING_DIR/package.json"
-
-if [ -d "$API_DIR/node_modules" ]; then
-  cp -rL "$API_DIR/node_modules" "$STAGING_DIR/node_modules"
-fi
-
 echo "Zipping to $OUTPUT..."
 rm -f "$OUTPUT"
 python3 -c "
 import zipfile, os, sys
-staging = sys.argv[1]
+bundle = sys.argv[1]
 output = sys.argv[2]
 with zipfile.ZipFile(output, 'w', zipfile.ZIP_DEFLATED) as zf:
-    for root, dirs, files in os.walk(staging):
-        for file in files:
-            abs_path = os.path.join(root, file)
-            arc_name = os.path.relpath(abs_path, staging)
-            zf.write(abs_path, arc_name)
-" "$STAGING_DIR" "$OUTPUT"
-
-echo "Cleaning up staging directory..."
-rm -rf "$STAGING_DIR"
+    zf.write(bundle, os.path.join('dist', os.path.basename(bundle)))
+" "$API_DIR/dist/index.js" "$OUTPUT"
 
 echo "Done: $OUTPUT"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@types/node':
         specifier: ^25.5.2
         version: 25.5.2
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
 
   packages/core:
     dependencies:


### PR DESCRIPTION
The Lambda packaging script was copying `packages/api/node_modules`, which in a pnpm workspace only contains direct dependencies as symlinks. Transitive deps like `@smithy/smithy-client` (required by `@aws-sdk/lib-dynamodb`) were missing, causing a `Runtime.ImportModuleError` on every cold start.

**Fix:** replace the tsc build + node_modules copy with an esbuild bundle that inlines all deps into a single `dist/index.js`. The package script now just zips that one file — no node_modules needed.