### PR TITLE
fix(api): include package.json in Lambda zip for ESM resolution

### DIFF
--- a/packages/api/scripts/package.sh
+++ b/packages/api/scripts/package.sh
@@ -12,10 +12,11 @@ echo "Zipping to $OUTPUT..."
 rm -f "$OUTPUT"
 python3 -c "
 import zipfile, os, sys
-bundle = sys.argv[1]
+api_dir = sys.argv[1]
 output = sys.argv[2]
 with zipfile.ZipFile(output, 'w', zipfile.ZIP_DEFLATED) as zf:
-    zf.write(bundle, os.path.join('dist', os.path.basename(bundle)))
-" "$API_DIR/dist/index.js" "$OUTPUT"
+    zf.write(os.path.join(api_dir, 'dist', 'index.js'), 'dist/index.js')
+    zf.write(os.path.join(api_dir, 'package.json'), 'package.json')
+" "$API_DIR" "$OUTPUT"
 
 echo "Done: $OUTPUT"


### PR DESCRIPTION
Without \`package.json\` (which has \`"type": "module"\`) in the zip, Node.js treats the esbuild ESM bundle as CJS and throws \`SyntaxError: Cannot use import statement outside a module\`.