### PR TITLE
fix(api): inject require shim for CJS deps in ESM bundle

### DIFF
--- a/packages/api/esbuild.config.mjs
+++ b/packages/api/esbuild.config.mjs
@@ -8,4 +8,7 @@ await esbuild.build({
   platform: "node",
   sourcemap: false,
   logLevel: "info",
+  banner: {
+    js: `import { createRequire } from "module"; const require = createRequire(import.meta.url);`,
+  },
 });

--- a/packages/api/scripts/package.sh
+++ b/packages/api/scripts/package.sh
@@ -12,10 +12,11 @@ echo "Zipping to $OUTPUT..."
 rm -f "$OUTPUT"
 python3 -c "
 import zipfile, os, sys
-bundle = sys.argv[1]
+api_dir = sys.argv[1]
 output = sys.argv[2]
 with zipfile.ZipFile(output, 'w', zipfile.ZIP_DEFLATED) as zf:
-    zf.write(bundle, os.path.join('dist', os.path.basename(bundle)))
-" "$API_DIR/dist/index.js" "$OUTPUT"
+    zf.write(os.path.join(api_dir, 'dist', 'index.js'), 'dist/index.js')
+    zf.write(os.path.join(api_dir, 'package.json'), 'package.json')
+" "$API_DIR" "$OUTPUT"
 
 echo "Done: $OUTPUT"


### PR DESCRIPTION
AWS SDK (@smithy) uses dynamic `require()` in its CJS dist files. When bundled in ESM format by esbuild, `require` is not available, causing:

```
Error: Dynamic require of "buffer" is not supported
```

Fix: inject a `createRequire` shim via esbuild `banner` option — the standard workaround for CJS packages bundled into ESM.