### PR TITLE
fix(api,infra): resolve SSM params at Lambda cold start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,13 @@
 Checklists, scratch pads, and other operational notes that should **not** be committed belong in `.working-docs/`. That directory is gitignored.
 
 Never put working documents in `docs/` or any other tracked directory.
+
+## Pull Request Hygiene
+
+Before asking the user to review or merge a PR, you **must** verify:
+
+1. **Branch is up to date** — rebase onto `main` and force-push if behind.
+2. **All CI checks pass** — use `gh run watch <run-id> --exit-status` to confirm build, lint, format, typecheck, and test jobs are green.
+3. **Format is clean** — run `pnpm format` locally before committing to avoid format-check failures in CI.
+
+Do not ask the user to merge until all three conditions are met.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,28 @@
+import { GetParametersCommand } from "@aws-sdk/client-ssm";
 import { handle } from "hono/aws-lambda";
 import { app } from "./app.js";
+import { ssmClient } from "./ssm.js";
+
+const SSM_MAPPINGS = [
+  { pathEnv: "GITHUB_CLIENT_ID_SSM_PATH", targetEnv: "GITHUB_CLIENT_ID" },
+  { pathEnv: "GITHUB_CLIENT_SECRET_SSM_PATH", targetEnv: "GITHUB_CLIENT_SECRET" },
+  { pathEnv: "JWT_SIGNING_SECRET_SSM_PATH", targetEnv: "JWT_SIGNING_SECRET" },
+] as const;
+
+const paths = SSM_MAPPINGS.map((m) => process.env[m.pathEnv]).filter(
+  (p): p is string => Boolean(p),
+);
+
+if (paths.length > 0) {
+  const { Parameters = [] } = await ssmClient.send(
+    new GetParametersCommand({ Names: paths, WithDecryption: true }),
+  );
+  for (const param of Parameters) {
+    const mapping = SSM_MAPPINGS.find((m) => process.env[m.pathEnv] === param.Name);
+    if (mapping && param.Value) {
+      process.env[mapping.targetEnv] = param.Value;
+    }
+  }
+}
 
 export const handler = handle(app);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,8 +9,8 @@ const SSM_MAPPINGS = [
   { pathEnv: "JWT_SIGNING_SECRET_SSM_PATH", targetEnv: "JWT_SIGNING_SECRET" },
 ] as const;
 
-const paths = SSM_MAPPINGS.map((m) => process.env[m.pathEnv]).filter(
-  (p): p is string => Boolean(p),
+const paths = SSM_MAPPINGS.map((m) => process.env[m.pathEnv]).filter((p): p is string =>
+  Boolean(p),
 );
 
 if (paths.length > 0) {

--- a/packages/infra/iam.tf
+++ b/packages/infra/iam.tf
@@ -72,7 +72,7 @@ resource "aws_iam_role_policy" "petroglyph_api_policy" {
       {
         Sid    = "SSMGetParameter"
         Effect = "Allow"
-        Action = "ssm:GetParameter"
+        Action = ["ssm:GetParameter", "ssm:GetParameters"]
         Resource = [
           "${local.ssm_arn_prefix}/petroglyph/github/*",
           "${local.ssm_arn_prefix}/petroglyph/jwt/*",

--- a/packages/infra/lambda_api.tf
+++ b/packages/infra/lambda_api.tf
@@ -23,6 +23,7 @@ resource "aws_lambda_function" "petroglyph_api" {
       GITHUB_CLIENT_ID_SSM_PATH     = aws_ssm_parameter.github_client_id.name
       GITHUB_CLIENT_SECRET_SSM_PATH = aws_ssm_parameter.github_client_secret.name
       JWT_SIGNING_SECRET_SSM_PATH   = aws_ssm_parameter.jwt_signing_secret.name
+      GITHUB_REDIRECT_URI           = "${aws_apigatewayv2_api.petroglyph_api.api_endpoint}/auth/callback"
     }
   }
 


### PR DESCRIPTION
The app reads `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `JWT_SIGNING_SECRET` directly from `process.env`, but the Lambda environment only had the `_SSM_PATH` variables set — the actual values were never fetched.

**Changes:**
- `index.ts`: fetch all three params from SSM at cold start using `GetParametersCommand`, populating `process.env` before the handler runs
- `lambda_api.tf`: add `GITHUB_REDIRECT_URI` computed from the API Gateway endpoint URL
- `iam.tf`: add `ssm:GetParameters` (plural) alongside existing `ssm:GetParameter`