### PR TITLE
fix(api,infra): wire all missing Lambda env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ test-output.txt
 *.tfstate.backup
 *.tfvars.json
 .terraform.tfstate.lock.info
+.ralph-state.json
+.ralph-*.log

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -7,6 +7,9 @@ const SSM_MAPPINGS = [
   { pathEnv: "GITHUB_CLIENT_ID_SSM_PATH", targetEnv: "GITHUB_CLIENT_ID" },
   { pathEnv: "GITHUB_CLIENT_SECRET_SSM_PATH", targetEnv: "GITHUB_CLIENT_SECRET" },
   { pathEnv: "JWT_SIGNING_SECRET_SSM_PATH", targetEnv: "JWT_SIGNING_SECRET" },
+  { pathEnv: "JWT_PRIVATE_KEY_SSM_PATH", targetEnv: "JWT_PRIVATE_KEY" },
+  { pathEnv: "JWT_PUBLIC_KEY_SSM_PATH", targetEnv: "JWT_PUBLIC_KEY" },
+  { pathEnv: "ONEDRIVE_CLIENT_ID_SSM_PATH", targetEnv: "MICROSOFT_CLIENT_ID" },
 ] as const;
 
 const paths = SSM_MAPPINGS.map((m) => process.env[m.pathEnv]).filter((p): p is string =>

--- a/packages/infra/iam.tf
+++ b/packages/infra/iam.tf
@@ -76,6 +76,7 @@ resource "aws_iam_role_policy" "petroglyph_api_policy" {
         Resource = [
           "${local.ssm_arn_prefix}/petroglyph/github/*",
           "${local.ssm_arn_prefix}/petroglyph/jwt/*",
+          "${local.ssm_arn_prefix}/petroglyph/onedrive/*",
         ]
       },
       {

--- a/packages/infra/lambda_api.tf
+++ b/packages/infra/lambda_api.tf
@@ -23,7 +23,17 @@ resource "aws_lambda_function" "petroglyph_api" {
       GITHUB_CLIENT_ID_SSM_PATH     = aws_ssm_parameter.github_client_id.name
       GITHUB_CLIENT_SECRET_SSM_PATH = aws_ssm_parameter.github_client_secret.name
       JWT_SIGNING_SECRET_SSM_PATH   = aws_ssm_parameter.jwt_signing_secret.name
+      JWT_PRIVATE_KEY_SSM_PATH      = aws_ssm_parameter.jwt_private_key.name
+      JWT_PUBLIC_KEY_SSM_PATH       = aws_ssm_parameter.jwt_public_key.name
+      ONEDRIVE_CLIENT_ID_SSM_PATH   = aws_ssm_parameter.onedrive_client_id.name
       GITHUB_REDIRECT_URI           = "${aws_apigatewayv2_api.petroglyph_api.api_endpoint}/auth/callback"
+      MICROSOFT_REDIRECT_URI        = "${aws_apigatewayv2_api.petroglyph_api.api_endpoint}/onedrive/connect"
+      GRAPH_NOTIFICATION_URL        = "${aws_apigatewayv2_api.petroglyph_api.api_endpoint}/onedrive/lifecycle"
+      REFRESH_TOKENS_TABLE          = aws_dynamodb_table.refresh_tokens.name
+      USERS_TABLE                   = aws_dynamodb_table.users.name
+      SYNC_PROFILES_TABLE           = aws_dynamodb_table.sync_profiles.name
+      FILE_RECORDS_TABLE            = aws_dynamodb_table.file_records.name
+      STAGED_PDFS_BUCKET            = aws_s3_bucket.staged_pdfs.id
     }
   }
 

--- a/packages/infra/ssm.tf
+++ b/packages/infra/ssm.tf
@@ -43,6 +43,34 @@ resource "aws_ssm_parameter" "jwt_signing_secret" {
   }
 }
 
+resource "aws_ssm_parameter" "jwt_private_key" {
+  name  = "/petroglyph/jwt/private-key"
+  type  = "SecureString"
+  value = "PLACEHOLDER"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = {
+    environment = terraform.workspace
+  }
+}
+
+resource "aws_ssm_parameter" "jwt_public_key" {
+  name  = "/petroglyph/jwt/public-key"
+  type  = "SecureString"
+  value = "PLACEHOLDER"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = {
+    environment = terraform.workspace
+  }
+}
+
 resource "aws_ssm_parameter" "onedrive_client_id" {
   name  = "/petroglyph/onedrive/client-id"
   type  = "SecureString"


### PR DESCRIPTION
## Summary

Completes the Lambda environment variable configuration so all routes have the resources they need.

### Added to Lambda env vars
- `USERS_TABLE`, `SYNC_PROFILES_TABLE`, `FILE_RECORDS_TABLE` — DynamoDB table names
- `STAGED_PDFS_BUCKET` — S3 bucket for staged PDFs
- `MICROSOFT_REDIRECT_URI` — OneDrive OAuth callback URL
- `GRAPH_NOTIFICATION_URL` — Microsoft Graph webhook URL
- `JWT_PRIVATE_KEY_SSM_PATH` / `JWT_PUBLIC_KEY_SSM_PATH` — paths to JWT signing key SSM params

### Infra
- Added `jwt_private_key` and `jwt_public_key` SSM parameters (SecureString, PLACEHOLDER values — set manually)
- Extended API Lambda IAM policy to allow `ssm:GetParameters` on `/petroglyph/onedrive/*`

### API
- Extended cold-start SSM resolution to also fetch JWT private/public keys and Microsoft client ID