### PR TITLE
feat(api): require returnUri on GET /auth/url (petroglyph-6gk)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: CD
+name: Deploy
 
 on:
   push:
@@ -76,6 +76,9 @@ jobs:
       AWS_REGION: eu-west-2
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
       - uses: actions/download-artifact@v4
         with:
           name: lambda-zip
@@ -117,3 +120,12 @@ jobs:
           terraform apply -auto-approve -refresh=false \
             -var="api_zip_s3_bucket=${{ secrets.LAMBDA_ARTIFACT_BUCKET }}" \
             -var="api_zip_s3_key=lambda-${{ steps.artifact-hash.outputs.hash }}.zip"
+      - name: Capture API function URL
+        id: api-function-url
+        working-directory: packages/infra
+        run: |
+          echo "url=$(terraform output -raw api_function_url)" >> "$GITHUB_OUTPUT"
+      - name: Smoke test deployed API
+        env:
+          LAMBDA_FUNCTION_URL: ${{ steps.api-function-url.outputs.url }}
+        run: node packages/api/scripts/smoke-test.ts

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Validate
 
 on:
   push:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,13 +101,13 @@ All AWS resources are provisioned with **Terraform**, with state stored remotely
 
 #### CD Pipeline
 
-Deployments to production are automated via `.github/workflows/cd.yml`, triggered on every push to `main`. The pipeline runs three sequential jobs:
+Deployments to production are automated via `.github/workflows/deploy.yml`, triggered on every push to `main`. The pipeline runs three sequential jobs:
 
-| Job       | Steps                                                                                                                                                                                            |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `build`   | `pnpm install` → `pnpm build` → `pnpm test`                                                                                                                                                      |
-| `package` | `pnpm --filter @petroglyph/api package` → uploads `lambda-<sha>.zip` to S3 (`LAMBDA_ARTIFACT_BUCKET`)                                                                                            |
-| `deploy`  | Downloads artifact, runs `terraform init` (S3 backend + DynamoDB locking), selects/creates the `production` workspace, runs `terraform apply` with `api_zip_s3_bucket` and `api_zip_s3_key` vars |
+| Job       | Steps                                                                                                                                                                                                                                                                    |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `build`   | `pnpm install` → `pnpm build` → `pnpm test`                                                                                                                                                                                                                              |
+| `package` | `pnpm --filter @petroglyph/api package` → uploads `lambda.zip` as a GitHub Actions artifact                                                                                                                                                                              |
+| `deploy`  | Downloads the artifact, computes a content hash, uploads `lambda-<sha256>.zip` to S3 (`LAMBDA_ARTIFACT_BUCKET`) if needed, runs `terraform init` (S3 backend + DynamoDB locking), selects/creates the `production` workspace, applies, then smoke-tests the deployed API |
 
 AWS access in the `deploy` job uses OIDC — no long-lived credentials are stored. The GitHub Actions role ARN is provided via the `AWS_ROLE_ARN` secret on the `production` environment.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Set the appropriate variables in your `.env` and follow the package-level instru
 
 ## CD Secrets
 
-The CD workflow (`.github/workflows/cd.yml`) requires three GitHub Actions secrets to be configured on the `production` environment. For full deployment and infrastructure setup instructions, see [docs/ops.md](docs/ops.md).
+The Deploy workflow (`.github/workflows/deploy.yml`) requires three GitHub Actions secrets to be configured on the `production` environment. For full deployment and infrastructure setup instructions, see [docs/ops.md](docs/ops.md).
 
 | Secret                   | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
@@ -150,7 +150,7 @@ The content-hash key is computed and exposed as a step output (`steps.artifact-h
 
 ## CI Alignment
 
-CI runs the same commands as local validation. The workflow is defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and triggers on push and pull requests targeting `main`. Each check runs in a parallel job after a shared `install` job warms the pnpm store cache.
+Validation runs the same commands as local validation. The workflow is defined in [`.github/workflows/validate.yml`](.github/workflows/validate.yml) and triggers on push and pull requests targeting `main`. Each check runs in a parallel job after a shared `install` job warms the pnpm store cache.
 
 The key local commands that align with CI jobs:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -59,12 +59,11 @@ sequenceDiagram
 4. Obsidian's URI handler fires; plugin sends the code to `POST /auth/callback` on the cloud API.
 5. Cloud API validates the state token against DynamoDB and **deletes it immediately** (making it one-time-use) before proceeding with the code exchange.
 
-`GET /auth/url` now requires a non-empty `returnUri` query parameter. The API returns `400` if it is missing or empty, and stores the value alongside the one-time OAuth state record in DynamoDB so the auth round-trip keeps the caller's intended return target bound to server-side state.
-6. Cloud API exchanges the code for a GitHub access token, calls `GET /api.github.com/user` to retrieve the user's GitHub ID and username. Any failure from GitHub returns **502** to the plugin.
-7. Cloud API creates (or looks up) the user record in DynamoDB. The GitHub token is discarded.
-8. Cloud API issues:
-   - A short-lived **JWT** (RS256, TTL 1 hour, claims: `iss=petroglyph-api`, `aud=petroglyph-plugin`, `sub=<userId>`, `username=<githubLogin>`).
-   - A long-lived **refresh token** (opaque UUID, stored as **SHA-256 hash** in DynamoDB, TTL ~90 days).
+`GET /auth/url` now requires a non-empty `returnUri` query parameter. The API returns `400` if it is missing or empty, and stores the value alongside the one-time OAuth state record in DynamoDB so the auth round-trip keeps the caller's intended return target bound to server-side state. 6. Cloud API exchanges the code for a GitHub access token, calls `GET /api.github.com/user` to retrieve the user's GitHub ID and username. Any failure from GitHub returns **502** to the plugin. 7. Cloud API creates (or looks up) the user record in DynamoDB. The GitHub token is discarded. 8. Cloud API issues:
+
+- A short-lived **JWT** (RS256, TTL 1 hour, claims: `iss=petroglyph-api`, `aud=petroglyph-plugin`, `sub=<userId>`, `username=<githubLogin>`).
+- A long-lived **refresh token** (opaque UUID, stored as **SHA-256 hash** in DynamoDB, TTL ~90 days).
+
 9. Plugin stores `jwt`, `refreshToken`, and `username` via Obsidian's `saveData` API (written to the plugin's local data file — not `localStorage`).
 
 ### Session Lifecycle

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -28,19 +28,29 @@ The plugin uses GitHub as an identity provider to authenticate the user against 
 sequenceDiagram
     participant Plugin
     participant CloudAPI as Cloud API
+    participant DynamoDB
     participant GitHub
 
-    Plugin->>CloudAPI: "Connect" clicked
-    CloudAPI-->>Plugin: redirect URL returned
-    Plugin->>GitHub: open browser (OAuth authorise URL)
-    GitHub-->>CloudAPI: user grants consent
-    GitHub-->>Plugin: obsidian://petroglyph/auth/callback?code=...
-    Plugin->>CloudAPI: POST /auth/callback {code}
-    CloudAPI->>GitHub: GET /user (GitHub API)
-    GitHub-->>CloudAPI: user profile
-    Note over CloudAPI: create/lookup user<br/>issue JWT + refresh token
+    Plugin->>CloudAPI: GET /auth/url?returnUri=obsidian://...
+    CloudAPI->>DynamoDB: store { state (UUID), returnUri, TTL 10 min }
+    CloudAPI-->>Plugin: { url: "github.com/login/oauth/authorize?...&state=..." }
+
+    Plugin->>GitHub: open browser to GitHub OAuth URL
+    Note over GitHub: user reviews scope<br/>and clicks "Authorise"
+    GitHub-->>Plugin: redirect browser to obsidian://petroglyph/auth/callback?code=xxx&state=xxx
+
+    Note over Plugin: Obsidian URI handler fires
+    Plugin->>CloudAPI: POST /auth/callback { code, state }
+    CloudAPI->>DynamoDB: lookup + delete state (one-time-use)
+    DynamoDB-->>CloudAPI: { returnUri, ttl }
+    CloudAPI->>GitHub: POST /login/oauth/access_token { code }
+    GitHub-->>CloudAPI: access_token
+    CloudAPI->>GitHub: GET /api.github.com/user
+    GitHub-->>CloudAPI: { id, login }
+    Note over CloudAPI: upsert user record<br/>issue JWT (1 h) + refresh token (90 d)
     CloudAPI-->>Plugin: { jwt, refreshToken, username }
-    Note over Plugin: store jwt, refreshToken, username<br/>via Obsidian saveData API
+
+    Note over Plugin: store jwt, refreshToken, username<br/>via Obsidian saveData API<br/>redirect to returnUri
 ```
 
 1. Plugin calls `GET /auth/url?returnUri=<obsidian-uri>` to obtain the GitHub OAuth authorisation URL.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -43,11 +43,13 @@ sequenceDiagram
     Note over Plugin: store jwt, refreshToken, username<br/>via Obsidian saveData API
 ```
 
-1. Plugin opens browser to GitHub's OAuth authorisation URL.
+1. Plugin calls `GET /auth/url?returnUri=<obsidian-uri>` to obtain the GitHub OAuth authorisation URL.
 2. User grants consent on GitHub.
 3. GitHub redirects to `obsidian://petroglyph/auth/callback?code=...`.
 4. Obsidian's URI handler fires; plugin sends the code to `POST /auth/callback` on the cloud API.
 5. Cloud API validates the state token against DynamoDB and **deletes it immediately** (making it one-time-use) before proceeding with the code exchange.
+
+`GET /auth/url` now requires a non-empty `returnUri` query parameter. The API returns `400` if it is missing or empty, and stores the value alongside the one-time OAuth state record in DynamoDB so the auth round-trip keeps the caller's intended return target bound to server-side state.
 6. Cloud API exchanges the code for a GitHub access token, calls `GET /api.github.com/user` to retrieve the user's GitHub ID and username. Any failure from GitHub returns **502** to the plugin.
 7. Cloud API creates (or looks up) the user record in DynamoDB. The GitHub token is discarded.
 8. Cloud API issues:
@@ -374,4 +376,4 @@ All parameters use the prefix `/petroglyph/`.
 - **Refresh token rotation** detects replay attacks: using a superseded refresh token immediately purges all active tokens for the user. The superseded flag is set via an atomic DynamoDB `UpdateItem` with a `ConditionExpression`, preventing a TOCTOU race where two concurrent requests with the same token could each pass a read-then-check validation.
 - **JWT key pair** uses RS256 (asymmetric). The public key is stored in SSM at `/petroglyph/jwt/public-key` (or overridden via `JWT_PUBLIC_KEY` env var) and is imported once at module level (cached for the lifetime of the Lambda process). Rotation of the key pair invalidates all active JWTs; users re-authenticate on the next API call via the refresh token.
 - **SSM SecureString** parameters are encrypted at rest using AWS KMS. Access is restricted to the Lambda execution roles via IAM.
-- **CSRF protection via server-side state tokens**: `GET /auth/url` generates a UUID state token, stores it in DynamoDB (`refresh_tokens` table, `type=oauth_state`, TTL 10 minutes), and includes it in the GitHub OAuth URL. The callback handler validates the state against DynamoDB and **deletes it before exchanging the code** (one-time-use), so the token cannot be replayed even if intercepted after the redirect. Validation survives any plugin restart or context loss during the OAuth redirect.
+- **CSRF protection via server-side state tokens**: `GET /auth/url` requires a non-empty `returnUri`, generates a UUID state token, stores both in DynamoDB (`refresh_tokens` table, `type=oauth_state`, TTL 10 minutes), and includes the state in the GitHub OAuth URL. The callback handler validates the state against DynamoDB and **deletes it before exchanging the code** (one-time-use), so the token cannot be replayed even if intercepted after the redirect. Keeping `returnUri` on the same short-lived state record means the server can trust the caller's intended return target without accepting it later as a separate callback input. Validation survives any plugin restart or context loss during the OAuth redirect.

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -44,8 +44,13 @@ app.get("/health", (c) => {
 app.get("/auth/url", async (c) => {
   const clientId = process.env["GITHUB_CLIENT_ID"];
   const redirectUri = process.env["GITHUB_REDIRECT_URI"];
+  const returnUri = c.req.query("returnUri");
   if (!clientId || !redirectUri) {
     return c.json({ error: "Missing OAuth configuration" }, 500);
+  }
+
+  if (typeof returnUri !== "string" || returnUri.length === 0) {
+    return c.json({ error: "returnUri is required" }, 400);
   }
 
   const state = randomUUID();
@@ -54,7 +59,7 @@ app.get("/auth/url", async (c) => {
   await docClient.send(
     new PutCommand({
       TableName: TABLE_NAME,
-      Item: { tokenHash: state, type: "oauth_state", ttl },
+      Item: { tokenHash: state, type: "oauth_state", ttl, returnUri },
     }),
   );
 

--- a/packages/api/src/auth-callback.test.ts
+++ b/packages/api/src/auth-callback.test.ts
@@ -306,7 +306,17 @@ describe("POST /auth/callback", () => {
     expect(putCmd.input.Item.ttl).toBeLessThanOrEqual(after + ninetyDays);
   });
 
-  // ── Behaviour 9: 200 { jwt, refreshToken, username } ─────────────────────
+  // ── Behaviour 9: 200 { jwt, refreshToken, username } — returnUri not leaked
+
+  it("does not include returnUri in the response body", async () => {
+    setupDynamoMock(makeStateItem());
+    setupFetchMock();
+
+    const res = await postCallback({ code: GITHUB_CODE, state: VALID_STATE });
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("returnUri");
+  });
 
   it("returns 200 with jwt, refreshToken, and username", async () => {
     setupDynamoMock(makeStateItem());

--- a/packages/api/src/auth-callback.test.ts
+++ b/packages/api/src/auth-callback.test.ts
@@ -34,15 +34,17 @@ const GITHUB_USER_ID = 12345;
 const GITHUB_USERNAME = "testuser";
 const GITHUB_ACCESS_TOKEN = "gha_test_token_xyz";
 
-function makeStateItem(overrides: Partial<{ ttl: number; type: string }> = {}): {
+function makeStateItem(overrides: Partial<{ ttl: number; type: string; returnUri: string }> = {}): {
   tokenHash: string;
   type: string;
   ttl: number;
+  returnUri: string;
 } {
   return {
     tokenHash: VALID_STATE,
     type: "oauth_state",
     ttl: Math.floor(Date.now() / 1000) + 600,
+    returnUri: "obsidian://petroglyph/open",
     ...overrides,
   };
 }
@@ -139,6 +141,19 @@ describe("POST /auth/callback", () => {
 
     it("returns 401 when state has wrong type", async () => {
       setupDynamoMock(makeStateItem({ type: "refresh_token" }));
+      setupFetchMock();
+
+      const res = await postCallback({ code: GITHUB_CODE, state: VALID_STATE });
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 when state is missing returnUri", async () => {
+      setupDynamoMock({
+        tokenHash: VALID_STATE,
+        type: "oauth_state",
+        ttl: Math.floor(Date.now() / 1000) + 600,
+      });
       setupFetchMock();
 
       const res = await postCallback({ code: GITHUB_CODE, state: VALID_STATE });

--- a/packages/api/src/auth-callback.test.ts
+++ b/packages/api/src/auth-callback.test.ts
@@ -314,7 +314,7 @@ describe("POST /auth/callback", () => {
 
     const res = await postCallback({ code: GITHUB_CODE, state: VALID_STATE });
 
-    const body = (await res.json()) as Record<string, unknown>;
+    const body = (await res.json()) as { [key: string]: unknown };
     expect(body).not.toHaveProperty("returnUri");
   });
 

--- a/packages/api/src/auth-callback.ts
+++ b/packages/api/src/auth-callback.ts
@@ -16,6 +16,7 @@ interface StateItem {
   tokenHash: string;
   type: string;
   ttl: number;
+  returnUri: string;
 }
 
 interface GitHubTokenResponse {
@@ -57,6 +58,16 @@ function hasNumberProp<K extends string>(
   return typeof value[key] === "number";
 }
 
+function isStateItem(value: unknown): value is StateItem {
+  return (
+    isRecord(value) &&
+    hasStringProp(value, "tokenHash") &&
+    hasStringProp(value, "type") &&
+    hasNumberProp(value, "ttl") &&
+    hasStringProp(value, "returnUri")
+  );
+}
+
 function parseGitHubTokenResponse(data: unknown): GitHubTokenResponse {
   if (!isRecord(data) || !hasStringProp(data, "access_token")) {
     throw new UpstreamError("Invalid GitHub token response shape");
@@ -78,7 +89,8 @@ async function lookUpState(state: string): Promise<StateItem | undefined> {
       Key: { tokenHash: state },
     }),
   );
-  return result.Item as StateItem | undefined;
+
+  return isStateItem(result.Item) ? result.Item : undefined;
 }
 
 async function deleteState(state: string): Promise<void> {

--- a/packages/api/src/auth-middleware.test.ts
+++ b/packages/api/src/auth-middleware.test.ts
@@ -121,7 +121,7 @@ describe("auth middleware", () => {
       vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
       vi.stubEnv("GITHUB_REDIRECT_URI", "obsidian://petroglyph/auth/callback");
 
-      const res = await app.request("/auth/url");
+      const res = await app.request("/auth/url?returnUri=obsidian%3A%2F%2Fpetroglyph%2Fopen");
       expect(res.status).toBe(200);
     });
   });

--- a/packages/api/src/auth-url.test.ts
+++ b/packages/api/src/auth-url.test.ts
@@ -9,6 +9,8 @@ vi.mock("./db.js", () => ({
 import { app } from "./app.js";
 
 describe("GET /auth/url", () => {
+  const returnUri = "obsidian://petroglyph/open";
+
   beforeEach(() => {
     vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
     vi.stubEnv("GITHUB_REDIRECT_URI", "obsidian://petroglyph/auth/callback");
@@ -19,15 +21,29 @@ describe("GET /auth/url", () => {
     vi.unstubAllEnvs();
   });
 
-  it("returns 200 with a url field", async () => {
+  it("returns 400 when returnUri is missing", async () => {
     const res = await app.request("/auth/url");
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "returnUri is required" });
+  });
+
+  it("returns 400 when returnUri is empty", async () => {
+    const res = await app.request("/auth/url?returnUri=");
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "returnUri is required" });
+  });
+
+  it("returns 200 with a url field", async () => {
+    const res = await app.request(`/auth/url?returnUri=${encodeURIComponent(returnUri)}`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { url: string };
     expect(typeof body.url).toBe("string");
   });
 
   it("URL contains correct query params", async () => {
-    const res = await app.request("/auth/url");
+    const res = await app.request(`/auth/url?returnUri=${encodeURIComponent(returnUri)}`);
     const body = (await res.json()) as { url: string };
     const url = new URL(body.url);
     expect(`${url.origin}${url.pathname}`).toBe("https://github.com/login/oauth/authorize");
@@ -38,8 +54,8 @@ describe("GET /auth/url", () => {
   });
 
   it("two calls produce distinct state tokens", async () => {
-    const res1 = await app.request("/auth/url");
-    const res2 = await app.request("/auth/url");
+    const res1 = await app.request(`/auth/url?returnUri=${encodeURIComponent(returnUri)}`);
+    const res2 = await app.request(`/auth/url?returnUri=${encodeURIComponent(returnUri)}`);
     const body1 = (await res1.json()) as { url: string };
     const body2 = (await res2.json()) as { url: string };
     const state1 = new URL(body1.url).searchParams.get("state");
@@ -47,9 +63,9 @@ describe("GET /auth/url", () => {
     expect(state1).not.toBe(state2);
   });
 
-  it("stores state token in DynamoDB with TTL and type=oauth_state", async () => {
+  it("stores state token in DynamoDB with TTL, type=oauth_state, and returnUri", async () => {
     const before = Math.floor(Date.now() / 1000);
-    const res = await app.request("/auth/url");
+    const res = await app.request(`/auth/url?returnUri=${encodeURIComponent(returnUri)}`);
     const after = Math.floor(Date.now() / 1000);
     const body = (await res.json()) as { url: string };
     const state = new URL(body.url).searchParams.get("state");
@@ -59,7 +75,7 @@ describe("GET /auth/url", () => {
       {
         input: {
           TableName: string;
-          Item: { tokenHash: string; type: string; ttl: number };
+          Item: { tokenHash: string; type: string; ttl: number; returnUri: string };
         };
       },
     ];
@@ -68,6 +84,7 @@ describe("GET /auth/url", () => {
       Item: {
         tokenHash: state,
         type: "oauth_state",
+        returnUri,
       },
     });
     expect(command.input.Item.ttl).toBeGreaterThanOrEqual(before + 600);

--- a/packages/infra/src/deploy-workflow.test.ts
+++ b/packages/infra/src/deploy-workflow.test.ts
@@ -5,33 +5,45 @@ import { describe, expect, it } from "vitest";
 
 const currentFilePath = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(currentFilePath), "../../..");
-const cdWorkflowPath = resolve(repoRoot, ".github/workflows/cd.yml");
+const deployWorkflowPath = resolve(repoRoot, ".github/workflows/deploy.yml");
 
-function readCdWorkflow(): string {
-  return readFileSync(cdWorkflowPath, "utf8");
+function readDeployWorkflow(): string {
+  return readFileSync(deployWorkflowPath, "utf8");
 }
 
-describe("CD workflow artifact handling", () => {
+describe("Deploy workflow artifact handling", () => {
   it("does not use github.sha as the S3 artifact key", () => {
-    const workflow = readCdWorkflow();
+    const workflow = readDeployWorkflow();
     expect(workflow).not.toMatch(/lambda-\$\{\{\s*github\.sha\s*\}\}\.zip/);
   });
 
   it("computes a content hash from the lambda zip before uploading", () => {
-    const workflow = readCdWorkflow();
+    const workflow = readDeployWorkflow();
     // The workflow must compute a SHA256 (or similar) of the zip file
     expect(workflow).toMatch(/sha256sum.*lambda\.zip/);
   });
 
   it("skips the S3 upload when an artifact with that content hash already exists", () => {
-    const workflow = readCdWorkflow();
+    const workflow = readDeployWorkflow();
     // The workflow must guard the upload with an existence check
     expect(workflow).toMatch(/head-object[\s\S]*lambda\.zip|lambda\.zip[\s\S]*head-object/);
   });
 
   it("passes the content-hash-based key to terraform apply", () => {
-    const workflow = readCdWorkflow();
+    const workflow = readDeployWorkflow();
     // api_zip_s3_key must reference a step output or env var, not github.sha
     expect(workflow).toMatch(/api_zip_s3_key.*steps\.|api_zip_s3_key.*env\./);
+  });
+
+  it("captures the deployed Lambda function URL from Terraform output", () => {
+    const workflow = readDeployWorkflow();
+    expect(workflow).toMatch(/terraform output -raw api_function_url/);
+  });
+
+  it("runs the deployed smoke test after terraform apply", () => {
+    const workflow = readDeployWorkflow();
+    expect(workflow).toMatch(
+      /Terraform apply[\s\S]*Capture API function URL[\s\S]*Smoke test deployed API[\s\S]*LAMBDA_FUNCTION_URL:\s*\$\{\{\s*steps\.api-function-url\.outputs\.url\s*\}\}[\s\S]*node packages\/api\/scripts\/smoke-test\.ts/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

`GET /auth/url` now requires a `?returnUri=` query parameter.

### Changes
- Returns 400 if `returnUri` is missing or empty
- Stores `returnUri` in the DynamoDB OAuth state item alongside `tokenHash` and `ttl`
- `StateItem` interface updated to require `returnUri: string`
- Auth URL, callback, and middleware tests updated

### Breaking change
All callers of `GET /auth/url` must now supply `?returnUri=`. Documented in `docs/authentication.md`.

---
Bead: petroglyph-6gk  
Stack: **1 of 3** → [2: workflow rename](#) → [3: smoke test](#)