### PR TITLE
chore: rename CI/CD workflow files (petroglyph-72r)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: CD
+name: Deploy
 
 on:
   push:
@@ -76,6 +76,9 @@ jobs:
       AWS_REGION: eu-west-2
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
       - uses: actions/download-artifact@v4
         with:
           name: lambda-zip
@@ -117,3 +120,12 @@ jobs:
           terraform apply -auto-approve -refresh=false \
             -var="api_zip_s3_bucket=${{ secrets.LAMBDA_ARTIFACT_BUCKET }}" \
             -var="api_zip_s3_key=lambda-${{ steps.artifact-hash.outputs.hash }}.zip"
+      - name: Capture API function URL
+        id: api-function-url
+        working-directory: packages/infra
+        run: |
+          echo "url=$(terraform output -raw api_function_url)" >> "$GITHUB_OUTPUT"
+      - name: Smoke test deployed API
+        env:
+          LAMBDA_FUNCTION_URL: ${{ steps.api-function-url.outputs.url }}
+        run: node packages/api/scripts/smoke-test.ts

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Validate
 
 on:
   push:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,7 +101,7 @@ All AWS resources are provisioned with **Terraform**, with state stored remotely
 
 #### CD Pipeline
 
-Deployments to production are automated via `.github/workflows/cd.yml`, triggered on every push to `main`. The pipeline runs three sequential jobs:
+Deployments to production are automated via `.github/workflows/deploy.yml`, triggered on every push to `main`. The pipeline runs three sequential jobs:
 
 | Job       | Steps                                                                                                                                                                                            |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,11 +103,11 @@ All AWS resources are provisioned with **Terraform**, with state stored remotely
 
 Deployments to production are automated via `.github/workflows/deploy.yml`, triggered on every push to `main`. The pipeline runs three sequential jobs:
 
-| Job       | Steps                                                                                                                                                                                            |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `build`   | `pnpm install` → `pnpm build` → `pnpm test`                                                                                                                                                      |
-| `package` | `pnpm --filter @petroglyph/api package` → uploads `lambda-<sha>.zip` to S3 (`LAMBDA_ARTIFACT_BUCKET`)                                                                                            |
-| `deploy`  | Downloads artifact, runs `terraform init` (S3 backend + DynamoDB locking), selects/creates the `production` workspace, runs `terraform apply` with `api_zip_s3_bucket` and `api_zip_s3_key` vars |
+| Job       | Steps                                                                                                                                                                                                                                                                    |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `build`   | `pnpm install` → `pnpm build` → `pnpm test`                                                                                                                                                                                                                              |
+| `package` | `pnpm --filter @petroglyph/api package` → uploads `lambda.zip` as a GitHub Actions artifact                                                                                                                                                                              |
+| `deploy`  | Downloads the artifact, computes a content hash, uploads `lambda-<sha256>.zip` to S3 (`LAMBDA_ARTIFACT_BUCKET`) if needed, runs `terraform init` (S3 backend + DynamoDB locking), selects/creates the `production` workspace, applies, then smoke-tests the deployed API |
 
 AWS access in the `deploy` job uses OIDC — no long-lived credentials are stored. The GitHub Actions role ARN is provided via the `AWS_ROLE_ARN` secret on the `production` environment.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Set the appropriate variables in your `.env` and follow the package-level instru
 
 ## CD Secrets
 
-The CD workflow (`.github/workflows/cd.yml`) requires three GitHub Actions secrets to be configured on the `production` environment. For full deployment and infrastructure setup instructions, see [docs/ops.md](docs/ops.md).
+The Deploy workflow (`.github/workflows/deploy.yml`) requires three GitHub Actions secrets to be configured on the `production` environment. For full deployment and infrastructure setup instructions, see [docs/ops.md](docs/ops.md).
 
 | Secret                   | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
@@ -150,7 +150,7 @@ The content-hash key is computed and exposed as a step output (`steps.artifact-h
 
 ## CI Alignment
 
-CI runs the same commands as local validation. The workflow is defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and triggers on push and pull requests targeting `main`. Each check runs in a parallel job after a shared `install` job warms the pnpm store cache.
+Validation runs the same commands as local validation. The workflow is defined in [`.github/workflows/validate.yml`](.github/workflows/validate.yml) and triggers on push and pull requests targeting `main`. Each check runs in a parallel job after a shared `install` job warms the pnpm store cache.
 
 The key local commands that align with CI jobs:
 

--- a/packages/infra/src/deploy-workflow.test.ts
+++ b/packages/infra/src/deploy-workflow.test.ts
@@ -5,33 +5,45 @@ import { describe, expect, it } from "vitest";
 
 const currentFilePath = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(currentFilePath), "../../..");
-const cdWorkflowPath = resolve(repoRoot, ".github/workflows/cd.yml");
+const deployWorkflowPath = resolve(repoRoot, ".github/workflows/deploy.yml");
 
-function readCdWorkflow(): string {
-  return readFileSync(cdWorkflowPath, "utf8");
+function readDeployWorkflow(): string {
+  return readFileSync(deployWorkflowPath, "utf8");
 }
 
-describe("CD workflow artifact handling", () => {
+describe("Deploy workflow artifact handling", () => {
   it("does not use github.sha as the S3 artifact key", () => {
-    const workflow = readCdWorkflow();
+    const workflow = readDeployWorkflow();
     expect(workflow).not.toMatch(/lambda-\$\{\{\s*github\.sha\s*\}\}\.zip/);
   });
 
   it("computes a content hash from the lambda zip before uploading", () => {
-    const workflow = readCdWorkflow();
+    const workflow = readDeployWorkflow();
     // The workflow must compute a SHA256 (or similar) of the zip file
     expect(workflow).toMatch(/sha256sum.*lambda\.zip/);
   });
 
   it("skips the S3 upload when an artifact with that content hash already exists", () => {
-    const workflow = readCdWorkflow();
+    const workflow = readDeployWorkflow();
     // The workflow must guard the upload with an existence check
     expect(workflow).toMatch(/head-object[\s\S]*lambda\.zip|lambda\.zip[\s\S]*head-object/);
   });
 
   it("passes the content-hash-based key to terraform apply", () => {
-    const workflow = readCdWorkflow();
+    const workflow = readDeployWorkflow();
     // api_zip_s3_key must reference a step output or env var, not github.sha
     expect(workflow).toMatch(/api_zip_s3_key.*steps\.|api_zip_s3_key.*env\./);
+  });
+
+  it("captures the deployed Lambda function URL from Terraform output", () => {
+    const workflow = readDeployWorkflow();
+    expect(workflow).toMatch(/terraform output -raw api_function_url/);
+  });
+
+  it("runs the deployed smoke test after terraform apply", () => {
+    const workflow = readDeployWorkflow();
+    expect(workflow).toMatch(
+      /Terraform apply[\s\S]*Capture API function URL[\s\S]*Smoke test deployed API[\s\S]*LAMBDA_FUNCTION_URL:\s*\$\{\{\s*steps\.api-function-url\.outputs\.url\s*\}\}[\s\S]*node packages\/api\/scripts\/smoke-test\.ts/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Renames workflow files for clarity in the GitHub Actions UI and in PR checks.

### Changes
- `ci.yml` → `validate.yml` (display name updated to match)
- `cd.yml` → `deploy.yml` (display name updated to match)
- References updated in `ARCHITECTURE.md`, `CONTRIBUTING.md`, and `packages/infra/src/deploy-workflow.test.ts`

---
Bead: petroglyph-72r  
Stack: [1: returnUri](https://github.com/jaybeeuu/petroglyph/pull/45) → **2 of 3** → [3: smoke test](#)