### PR TITLE
feat(api): add deployed smoke test for /health and /auth/url (petroglyph-m73)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,6 @@ jobs:
             node_modules
             packages/*/node_modules
           key: deps-${{ hashFiles('pnpm-lock.yaml') }}
-      - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@v4
         with:
           name: lambda-zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,9 +76,20 @@ jobs:
       AWS_REGION: eu-west-2
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v5
+        with:
+          version: "10.4.1"
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/pnpm/store
+            node_modules
+            packages/*/node_modules
+          key: deps-${{ hashFiles('pnpm-lock.yaml') }}
+      - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@v4
         with:
           name: lambda-zip
@@ -128,4 +139,4 @@ jobs:
       - name: Smoke test deployed API
         env:
           LAMBDA_FUNCTION_URL: ${{ steps.api-function-url.outputs.url }}
-        run: node packages/api/scripts/smoke-test.ts
+        run: pnpm --filter @petroglyph/api smoke-test

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,6 +109,8 @@ Deployments to production are automated via `.github/workflows/deploy.yml`, trig
 | `package` | `pnpm --filter @petroglyph/api package` → uploads `lambda.zip` as a GitHub Actions artifact                                                                                                                                                                              |
 | `deploy`  | Downloads the artifact, computes a content hash, uploads `lambda-<sha256>.zip` to S3 (`LAMBDA_ARTIFACT_BUCKET`) if needed, runs `terraform init` (S3 backend + DynamoDB locking), selects/creates the `production` workspace, applies, then smoke-tests the deployed API |
 
+That post-deploy smoke gate calls `/health` and `/auth/url` against the deployed Lambda function URL. The workflow reads that URL from the Terraform output `api_function_url`, so the output remains part of the deployment contract.
+
 AWS access in the `deploy` job uses OIDC — no long-lived credentials are stored. The GitHub Actions role ARN is provided via the `AWS_ROLE_ARN` secret on the `production` environment.
 
 The `deploy` job targets the `production` GitHub Actions environment, which can restrict deploys to `main` and require reviewer approval before production deployment proceeds.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,8 @@
     "@types/aws-lambda": "^8.10.145",
     "@types/node": "^25.5.2",
     "esbuild": "^0.28.0",
-    "openapi-typescript": "^7.13.0"
+    "openapi-typescript": "^7.13.0",
+    "tsx": "^4.21.0"
   },
   "scripts": {
     "build": "node esbuild.config.mjs",
@@ -16,6 +17,7 @@
     "generate-types": "openapi-typescript openapi.yaml -o src/openapi-types.ts",
     "lint": "eslint .",
     "prebuild": "pnpm generate-types",
+    "smoke-test": "tsx scripts/smoke-test.ts",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/api/scripts/smoke-test.ts
+++ b/packages/api/scripts/smoke-test.ts
@@ -15,6 +15,7 @@ const REQUEST_TIMEOUT_MS = Number.parseInt(
   process.env["SMOKE_TEST_REQUEST_TIMEOUT_MS"] ?? "10000",
   10,
 );
+const AUTH_URL_PATH = "/auth/url?returnUri=https%3A%2F%2Fexample.com";
 const lambdaFunctionUrl = process.env["LAMBDA_FUNCTION_URL"];
 
 function getErrorMessage(error: unknown): string {
@@ -162,7 +163,7 @@ async function main(): Promise<void> {
 
   for (const [path, validator] of [
     ["/health", assertStatusOkResponse],
-    ["/auth/url", assertGitHubAuthUrlResponse],
+    [AUTH_URL_PATH, assertGitHubAuthUrlResponse],
   ] satisfies ReadonlyArray<readonly [string, (body: unknown) => void]>) {
     try {
       const result = await runSmokeTest(path, validator);

--- a/packages/api/scripts/smoke-test.ts
+++ b/packages/api/scripts/smoke-test.ts
@@ -1,0 +1,190 @@
+interface UnknownObject {
+  readonly [key: string]: unknown;
+}
+
+interface SmokeTestResult {
+  readonly path: string;
+  readonly durationMs: number;
+}
+
+const MAX_RESPONSE_TIME_MS = Number.parseInt(
+  process.env["SMOKE_TEST_MAX_RESPONSE_TIME_MS"] ?? "5000",
+  10,
+);
+const REQUEST_TIMEOUT_MS = Number.parseInt(
+  process.env["SMOKE_TEST_REQUEST_TIMEOUT_MS"] ?? "10000",
+  10,
+);
+const lambdaFunctionUrl = process.env["LAMBDA_FUNCTION_URL"];
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function isRecord(value: unknown): value is UnknownObject {
+  return typeof value === "object" && value !== null;
+}
+
+function assertConfiguredNumber(value: number, name: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+}
+
+function assertStatusOkResponse(body: unknown): void {
+  if (!isRecord(body) || body["status"] !== "ok") {
+    throw new Error('Expected /health response body to equal {"status":"ok"}');
+  }
+}
+
+function assertGitHubAuthUrlResponse(body: unknown): void {
+  if (!isRecord(body) || typeof body["url"] !== "string") {
+    throw new Error('Expected /auth/url response body to include a string "url" field');
+  }
+
+  const authUrl = new URL(body["url"]);
+
+  if (
+    authUrl.protocol !== "https:" ||
+    authUrl.host !== "github.com" ||
+    authUrl.pathname !== "/login/oauth/authorize"
+  ) {
+    throw new Error(`Expected GitHub OAuth URL, received ${authUrl.toString()}`);
+  }
+
+  const clientId = authUrl.searchParams.get("client_id");
+  const redirectUri = authUrl.searchParams.get("redirect_uri");
+  const scope = authUrl.searchParams.get("scope");
+  const state = authUrl.searchParams.get("state");
+
+  if (!clientId) {
+    throw new Error("Expected GitHub OAuth URL to include client_id");
+  }
+
+  if (!redirectUri) {
+    throw new Error("Expected GitHub OAuth URL to include redirect_uri");
+  }
+
+  if (scope !== "read:user") {
+    throw new Error(`Expected GitHub OAuth URL scope=read:user, received ${scope ?? "<missing>"}`);
+  }
+
+  if (!state) {
+    throw new Error("Expected GitHub OAuth URL to include state");
+  }
+}
+
+function assertResponseTime(durationMs: number, path: string): void {
+  if (durationMs >= MAX_RESPONSE_TIME_MS) {
+    throw new Error(
+      `${path} responded in ${durationMs}ms, which exceeds the ${MAX_RESPONSE_TIME_MS}ms threshold`,
+    );
+  }
+}
+
+async function fetchJson(
+  path: string,
+): Promise<{ readonly body: unknown; readonly durationMs: number }> {
+  if (!lambdaFunctionUrl) {
+    throw new Error("LAMBDA_FUNCTION_URL is required");
+  }
+
+  const requestUrl = new URL(path, lambdaFunctionUrl);
+  const startedAt = performance.now();
+  const response = await fetch(requestUrl, {
+    headers: {
+      accept: "application/json",
+    },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const durationMs = Math.round(performance.now() - startedAt);
+  const responseText = await response.text();
+
+  if (response.status !== 200) {
+    throw new Error(`${path} returned ${response.status}: ${responseText}`);
+  }
+
+  let body: unknown;
+
+  try {
+    body = JSON.parse(responseText) as unknown;
+  } catch (error) {
+    throw new Error(`${path} returned invalid JSON: ${getErrorMessage(error)}`);
+  }
+
+  return {
+    body,
+    durationMs,
+  };
+}
+
+async function runSmokeTest(
+  path: string,
+  validateBody: (body: unknown) => void,
+): Promise<SmokeTestResult> {
+  const { body, durationMs } = await fetchJson(path);
+
+  validateBody(body);
+  assertResponseTime(durationMs, path);
+
+  console.log(`PASS ${path} (${durationMs}ms)`);
+
+  return {
+    path,
+    durationMs,
+  } satisfies SmokeTestResult;
+}
+
+async function main(): Promise<void> {
+  if (!lambdaFunctionUrl) {
+    console.error("Smoke test failed: LAMBDA_FUNCTION_URL is required");
+    process.exit(1);
+  }
+
+  assertConfiguredNumber(MAX_RESPONSE_TIME_MS, "SMOKE_TEST_MAX_RESPONSE_TIME_MS");
+  assertConfiguredNumber(REQUEST_TIMEOUT_MS, "SMOKE_TEST_REQUEST_TIMEOUT_MS");
+
+  try {
+    new URL(lambdaFunctionUrl);
+  } catch (error) {
+    console.error(`Smoke test failed: invalid LAMBDA_FUNCTION_URL (${getErrorMessage(error)})`);
+    process.exit(1);
+  }
+
+  console.log(`Running smoke test against ${lambdaFunctionUrl}`);
+
+  const failures: string[] = [];
+  const results: SmokeTestResult[] = [];
+
+  for (const [path, validator] of [
+    ["/health", assertStatusOkResponse],
+    ["/auth/url", assertGitHubAuthUrlResponse],
+  ] satisfies ReadonlyArray<readonly [string, (body: unknown) => void]>) {
+    try {
+      const result = await runSmokeTest(path, validator);
+      results.push(result);
+    } catch (error) {
+      const message = `${path}: ${getErrorMessage(error)}`;
+      failures.push(message);
+      console.error(`FAIL ${message}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error("Smoke test failed");
+    for (const failure of failures) {
+      console.error(` - ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  const slowestResponseMs = Math.max(...results.map((result) => result.durationMs));
+  console.log(`Smoke test passed (slowest response ${slowestResponseMs}ms)`);
+  process.exit(0);
+}
+
+await main();

--- a/packages/infra/src/deploy-workflow.test.ts
+++ b/packages/infra/src/deploy-workflow.test.ts
@@ -43,7 +43,7 @@ describe("Deploy workflow artifact handling", () => {
   it("runs the deployed smoke test after terraform apply", () => {
     const workflow = readDeployWorkflow();
     expect(workflow).toMatch(
-      /Terraform apply[\s\S]*Capture API function URL[\s\S]*Smoke test deployed API[\s\S]*LAMBDA_FUNCTION_URL:\s*\$\{\{\s*steps\.api-function-url\.outputs\.url\s*\}\}[\s\S]*node packages\/api\/scripts\/smoke-test\.ts/,
+      /Terraform apply[\s\S]*Capture API function URL[\s\S]*Smoke test deployed API[\s\S]*LAMBDA_FUNCTION_URL:\s*\$\{\{\s*steps\.api-function-url\.outputs\.url\s*\}\}[\s\S]*pnpm --filter @petroglyph\/api smoke-test/,
     );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 8.57.0(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.0
-        version: 4.0.18(@types/node@25.5.2)(yaml@2.8.3)
+        version: 4.0.18(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/api:
     dependencies:
@@ -72,6 +72,9 @@ importers:
       openapi-typescript:
         specifier: ^7.13.0
         version: 7.13.0(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
 
   packages/api-client:
     dependencies:
@@ -1688,6 +1691,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -1913,6 +1919,9 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1989,6 +1998,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4078,13 +4092,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.5.2)(yaml@2.8.3))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.2)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -4391,6 +4405,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -4578,6 +4596,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -4658,6 +4678,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -4685,7 +4712,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@7.3.1(@types/node@25.5.2)(yaml@2.8.3):
+  vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4696,12 +4723,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.2
       fsevents: 2.3.3
+      tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.0.18(@types/node@25.5.2)(yaml@2.8.3):
+  vitest@4.0.18(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.5.2)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -4718,7 +4746,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.5.2)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.2


### PR DESCRIPTION
## Summary

Adds a post-deploy smoke gate to the CD pipeline.

### Changes
- New `packages/api/scripts/smoke-test.ts` — standalone Node/tsx script (no test framework)
  - GETs `/health`, verifies 200 + `{"status":"ok"}`
  - GETs `/auth/url?returnUri=https://example.com`, verifies 200 + GitHub OAuth URL
  - Enforces < 5s response time per endpoint
  - Exits 0 on full pass, 1 on any failure
- `deploy.yml` wired to extract `api_function_url` from Terraform output and run `pnpm --filter @petroglyph/api smoke-test` after `terraform apply`
- CD pipeline smoke gate documented in `ARCHITECTURE.md`

---
Bead: petroglyph-m73  
Stack: [1: returnUri](https://github.com/jaybeeuu/petroglyph/pull/45) → [2: workflow rename](https://github.com/jaybeeuu/petroglyph/pull/46) → **3 of 3**