### PR TITLE
fix(api): use tokenHash key in onedrive state DynamoDB items

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -27,6 +27,7 @@
     "@aws-sdk/client-ssm": "^3.1024.0",
     "@aws-sdk/lib-dynamodb": "^3.1024.0",
     "@aws-sdk/s3-request-presigner": "^3.1024.0",
+    "@jaybeeuu/is": "^2.1.1",
     "@petroglyph/core": "workspace:*",
     "hono": "^4.12.10",
     "jose": "^6.2.2",

--- a/packages/api/src/onedrive-auth-url.test.ts
+++ b/packages/api/src/onedrive-auth-url.test.ts
@@ -85,14 +85,14 @@ describe("GET /onedrive/auth-url", () => {
       {
         input: {
           TableName: string;
-          Item: { token: string; type: string; verifier: string; ttl: number };
+          Item: { tokenHash: string; type: string; verifier: string; ttl: number };
         };
       },
     ];
     expect(command.input).toMatchObject({
       TableName: "petroglyph-refresh_tokens-default",
       Item: {
-        token: state,
+        tokenHash: state,
         type: "onedrive_state",
       },
     });

--- a/packages/api/src/onedrive-auth-url.ts
+++ b/packages/api/src/onedrive-auth-url.ts
@@ -33,7 +33,7 @@ export async function handleOnedriveAuthUrl(
   await docClient.send(
     new PutCommand({
       TableName: TABLE_NAME,
-      Item: { token: state, type: "onedrive_state", verifier, ttl },
+      Item: { tokenHash: state, type: "onedrive_state", verifier, ttl },
     }),
   );
 

--- a/packages/api/src/onedrive-connect.test.ts
+++ b/packages/api/src/onedrive-connect.test.ts
@@ -48,7 +48,7 @@ function makeStateItem(
   overrides: Partial<{ ttl: number; type: string; verifier: string }> = {},
 ): object {
   return {
-    token: VALID_STATE,
+    tokenHash: VALID_STATE,
     type: "onedrive_state",
     verifier: VALID_VERIFIER,
     ttl: Math.floor(Date.now() / 1000) + 600,
@@ -220,8 +220,8 @@ describe("POST /onedrive/connect", () => {
 
     const deleteCalls = mockDbSend.mock.calls.filter(([cmd]) => cmd instanceof DeleteCommand);
     expect(deleteCalls).toHaveLength(1);
-    const [deleteCmd] = deleteCalls[0] as [{ input: { Key: { token: string } } }];
-    expect(deleteCmd.input.Key.token).toBe(VALID_STATE);
+    const [deleteCmd] = deleteCalls[0] as [{ input: { Key: { tokenHash: string } } }];
+    expect(deleteCmd.input.Key.tokenHash).toBe(VALID_STATE);
   });
 
   // ── Behaviour 4: Microsoft token exchange success ────────────────────────

--- a/packages/api/src/onedrive-connect.ts
+++ b/packages/api/src/onedrive-connect.ts
@@ -23,7 +23,7 @@ interface ConnectRequestBody {
 }
 
 interface OnedriveStateItem {
-  token: string;
+  tokenHash: string;
   type: string;
   verifier: string;
   ttl: number;
@@ -55,12 +55,12 @@ function parseConnectBody(body: unknown): ConnectRequestBody | null {
 
 function parseOnedriveStateItem(item: unknown): OnedriveStateItem | null {
   if (!isRecord(item)) return null;
-  if (typeof item["token"] !== "string") return null;
+  if (typeof item["tokenHash"] !== "string") return null;
   if (typeof item["type"] !== "string") return null;
   if (typeof item["verifier"] !== "string") return null;
   if (typeof item["ttl"] !== "number") return null;
   return {
-    token: item["token"],
+    tokenHash: item["tokenHash"],
     type: item["type"],
     verifier: item["verifier"],
     ttl: item["ttl"],
@@ -87,7 +87,7 @@ async function lookupStateItem(state: string): Promise<OnedriveStateItem | null>
   const result = await docClient.send(
     new GetCommand({
       TableName: refreshTokensTable(),
-      Key: { token: state },
+      Key: { tokenHash: state },
     }),
   );
   return parseOnedriveStateItem(result.Item);
@@ -97,7 +97,7 @@ async function deleteStateItem(state: string): Promise<void> {
   await docClient.send(
     new DeleteCommand({
       TableName: refreshTokensTable(),
-      Key: { token: state },
+      Key: { tokenHash: state },
     }),
   );
 }

--- a/packages/api/src/onedrive-connect.ts
+++ b/packages/api/src/onedrive-connect.ts
@@ -1,3 +1,4 @@
+import { is, isObject } from "@jaybeeuu/is";
 import { PutParameterCommand } from "@aws-sdk/client-ssm";
 import { DeleteCommand, GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { Context } from "hono";
@@ -42,55 +43,32 @@ class UpstreamError extends Error {
   }
 }
 
-function isRecord(value: unknown): value is { [key: string]: unknown } {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function hasStringProp<K extends string>(
-  value: { [key: string]: unknown },
-  key: K,
-): value is { [key: string]: unknown } & { [P in K]: string } {
-  return typeof value[key] === "string";
-}
-
-function hasNumberProp<K extends string>(
-  value: { [key: string]: unknown },
-  key: K,
-): value is { [key: string]: unknown } & { [P in K]: number } {
-  return typeof value[key] === "number";
-}
-
 function parseConnectBody(body: unknown): ConnectRequestBody | null {
-  if (!isRecord(body)) return null;
-  if (typeof body["code"] !== "string" || body["code"].length === 0) return null;
-  if (typeof body["state"] !== "string" || body["state"].length === 0) return null;
-  return { code: body["code"], state: body["state"] };
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return null;
+  const b = body as Record<string, unknown>;
+  if (typeof b["code"] !== "string" || b["code"].length === 0) return null;
+  if (typeof b["state"] !== "string" || b["state"].length === 0) return null;
+  return { code: b["code"], state: b["state"] };
 }
 
-function isOnedriveStateItem(value: unknown): value is OnedriveStateItem {
-  return (
-    isRecord(value) &&
-    hasStringProp(value, "tokenHash") &&
-    hasStringProp(value, "type") &&
-    hasStringProp(value, "verifier") &&
-    hasNumberProp(value, "ttl")
-  );
-}
+const isOnedriveStateItem = isObject<OnedriveStateItem>({
+  tokenHash: is("string"),
+  type: is("string"),
+  verifier: is("string"),
+  ttl: is("number"),
+});
+
+const isMicrosoftTokenResponse = isObject<MicrosoftTokenResponse>({
+  access_token: is("string"),
+  refresh_token: is("string"),
+  expires_in: is("number"),
+});
 
 function parseMicrosoftTokenResponse(data: unknown): MicrosoftTokenResponse {
-  if (
-    !isRecord(data) ||
-    typeof data["access_token"] !== "string" ||
-    typeof data["refresh_token"] !== "string" ||
-    typeof data["expires_in"] !== "number"
-  ) {
+  if (!isMicrosoftTokenResponse(data)) {
     throw new UpstreamError("Invalid Microsoft token response shape");
   }
-  return {
-    access_token: data["access_token"],
-    refresh_token: data["refresh_token"],
-    expires_in: data["expires_in"],
-  };
+  return data;
 }
 
 async function lookupStateItem(state: string): Promise<OnedriveStateItem | null> {

--- a/packages/api/src/onedrive-connect.ts
+++ b/packages/api/src/onedrive-connect.ts
@@ -46,6 +46,20 @@ function isRecord(value: unknown): value is { [key: string]: unknown } {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function hasStringProp<K extends string>(
+  value: { [key: string]: unknown },
+  key: K,
+): value is { [key: string]: unknown } & { [P in K]: string } {
+  return typeof value[key] === "string";
+}
+
+function hasNumberProp<K extends string>(
+  value: { [key: string]: unknown },
+  key: K,
+): value is { [key: string]: unknown } & { [P in K]: number } {
+  return typeof value[key] === "number";
+}
+
 function parseConnectBody(body: unknown): ConnectRequestBody | null {
   if (!isRecord(body)) return null;
   if (typeof body["code"] !== "string" || body["code"].length === 0) return null;
@@ -53,18 +67,14 @@ function parseConnectBody(body: unknown): ConnectRequestBody | null {
   return { code: body["code"], state: body["state"] };
 }
 
-function parseOnedriveStateItem(item: unknown): OnedriveStateItem | null {
-  if (!isRecord(item)) return null;
-  if (typeof item["tokenHash"] !== "string") return null;
-  if (typeof item["type"] !== "string") return null;
-  if (typeof item["verifier"] !== "string") return null;
-  if (typeof item["ttl"] !== "number") return null;
-  return {
-    tokenHash: item["tokenHash"],
-    type: item["type"],
-    verifier: item["verifier"],
-    ttl: item["ttl"],
-  };
+function isOnedriveStateItem(value: unknown): value is OnedriveStateItem {
+  return (
+    isRecord(value) &&
+    hasStringProp(value, "tokenHash") &&
+    hasStringProp(value, "type") &&
+    hasStringProp(value, "verifier") &&
+    hasNumberProp(value, "ttl")
+  );
 }
 
 function parseMicrosoftTokenResponse(data: unknown): MicrosoftTokenResponse {
@@ -90,7 +100,7 @@ async function lookupStateItem(state: string): Promise<OnedriveStateItem | null>
       Key: { tokenHash: state },
     }),
   );
-  return parseOnedriveStateItem(result.Item);
+  return isOnedriveStateItem(result.Item) ? result.Item : null;
 }
 
 async function deleteStateItem(state: string): Promise<void> {

--- a/packages/api/src/onedrive-connect.ts
+++ b/packages/api/src/onedrive-connect.ts
@@ -45,7 +45,7 @@ class UpstreamError extends Error {
 
 function parseConnectBody(body: unknown): ConnectRequestBody | null {
   if (typeof body !== "object" || body === null || Array.isArray(body)) return null;
-  const b = body as Record<string, unknown>;
+  const b = body as { [key: string]: unknown };
   if (typeof b["code"] !== "string" || b["code"].length === 0) return null;
   if (typeof b["state"] !== "string" || b["state"].length === 0) return null;
   return { code: b["code"], state: b["state"] };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1024.0
         version: 3.1030.0
+      '@jaybeeuu/is':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@petroglyph/core':
         specifier: workspace:*
         version: link:../core
@@ -855,11 +858,26 @@ packages:
     peerDependencies:
       eslint: ^9.9.1
 
+  '@jaybeeuu/is@2.1.1':
+    resolution: {integrity: sha512-cpLCx9BDeWj3rrMLTL9bCk6THJ+DxWITkCJKLmeyfocmNz/s2OeVXNlhUg0IG4fOQeSeqBWE3ooqs5fFKnhu9w==}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@redocly/ajv@8.11.2':
     resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
@@ -1331,6 +1349,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@ts-morph/common@0.27.0':
+    resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
   '@types/aws-lambda@8.10.161':
     resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
 
@@ -1505,6 +1526,10 @@ packages:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1523,6 +1548,9 @@ packages:
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -1649,6 +1677,10 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -1662,6 +1694,9 @@ packages:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
     hasBin: true
 
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1674,6 +1709,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -1693,6 +1732,10 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1750,6 +1793,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1776,6 +1823,9 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -1795,6 +1845,14 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -1868,6 +1926,9 @@ packages:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1885,6 +1946,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
@@ -1911,6 +1976,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1922,10 +1990,17 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1990,11 +2065,18 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-morph@26.0.0:
+    resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3305,9 +3387,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@jaybeeuu/is@2.1.1':
+    dependencies:
+      json-schema-typed: 8.0.2
+      ts-morph: 26.0.0
+      tslib: 2.8.1
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@marijn/find-cluster-break@1.0.2': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@redocly/ajv@8.11.2':
     dependencies:
@@ -3958,6 +4058,12 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@ts-morph/common@0.27.0':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 10.2.4
+      path-browserify: 1.0.1
+
   '@types/aws-lambda@8.10.161': {}
 
   '@types/chai@5.2.3':
@@ -4170,6 +4276,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   callsites@3.1.0: {}
 
   chai@6.2.2: {}
@@ -4186,6 +4296,8 @@ snapshots:
       supports-color: 7.2.0
 
   change-case@5.4.4: {}
+
+  code-block-writer@13.0.3: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -4368,6 +4480,14 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -4382,6 +4502,10 @@ snapshots:
       path-expression-matcher: 1.2.1
       strnum: 2.2.2
 
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -4389,6 +4513,10 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   find-up@5.0.0:
     dependencies:
@@ -4408,6 +4536,10 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob-parent@6.0.2:
     dependencies:
@@ -4449,6 +4581,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-number@7.0.0: {}
+
   isexe@2.0.0: {}
 
   jose@6.2.2: {}
@@ -4466,6 +4600,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4487,6 +4623,13 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
 
   minimatch@10.2.4:
     dependencies:
@@ -4566,6 +4709,8 @@ snapshots:
       index-to-position: 1.2.0
       type-fest: 4.41.0
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.2.1: {}
@@ -4575,6 +4720,8 @@ snapshots:
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.3: {}
 
@@ -4592,11 +4739,15 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  queue-microtask@1.2.3: {}
+
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  reusify@1.1.0: {}
 
   rollup@4.59.0:
     dependencies:
@@ -4628,6 +4779,10 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   semver@7.7.4: {}
 
@@ -4672,9 +4827,18 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-morph@26.0.0:
+    dependencies:
+      '@ts-morph/common': 0.27.0
+      code-block-writer: 13.0.3
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
## Problem
`GET /onedrive/auth-url` was returning 500 with:
`ValidationException: Missing the key tokenHash in the item`

## Root cause
The `refresh-tokens` DynamoDB table's partition key is `tokenHash`, but `handleOnedriveAuthUrl` was writing items with `token` as the key field. The corresponding lookups and deletes in `onedrive-connect.ts` also used `token`.

## Fix
Renamed `token` → `tokenHash` in:
- `onedrive-auth-url.ts` — the DynamoDB PutItem
- `onedrive-connect.ts` — the interface, parser, GetItem, and DeleteItem
- Both test files to match