### PR TITLE
fix: use custom domain for OAuth redirect URIs in Terraform

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -142,9 +142,12 @@ Used for OneDrive connection (`GET /onedrive/auth-url` → `GET /onedrive/connec
    | Field | Value |
    |---|---|
    | Name | `petroglyph` |
-   | Supported account types | **Accounts in any organizational directory and personal Microsoft accounts** (the "Any Entra ID Tenant + Personal Microsoft accounts" option) |
+   | Supported account types | **Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)** |
    | Redirect URI platform | **Web** |
    | Redirect URI | `https://api.petroglyph.page/onedrive/connect` |
+
+   > **⚠ Important — Supported account types**: The value above must be selected exactly. If you choose a single-tenant or organisation-only option, personal Microsoft account holders will receive an `unauthorized_client: The client does not exist or is not enabled for consumers` error when attempting to connect OneDrive.
+
 3. Click **Register**. Copy the **Application (client) ID** from the overview page.
 4. Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**. Add:
    - `Files.Read`

--- a/packages/infra/custom_domain.tf
+++ b/packages/infra/custom_domain.tf
@@ -17,6 +17,7 @@
 
 locals {
   has_custom_domain = var.api_custom_domain != ""
+  api_base_url      = local.has_custom_domain ? "https://${var.api_custom_domain}" : aws_apigatewayv2_api.petroglyph_api.api_endpoint
 }
 
 resource "aws_acm_certificate" "api" {

--- a/packages/infra/lambda_api.tf
+++ b/packages/infra/lambda_api.tf
@@ -26,9 +26,9 @@ resource "aws_lambda_function" "petroglyph_api" {
       JWT_PRIVATE_KEY_SSM_PATH      = aws_ssm_parameter.jwt_private_key.name
       JWT_PUBLIC_KEY_SSM_PATH       = aws_ssm_parameter.jwt_public_key.name
       ONEDRIVE_CLIENT_ID_SSM_PATH   = aws_ssm_parameter.onedrive_client_id.name
-      GITHUB_REDIRECT_URI           = "${aws_apigatewayv2_api.petroglyph_api.api_endpoint}/auth/callback"
-      MICROSOFT_REDIRECT_URI        = "${aws_apigatewayv2_api.petroglyph_api.api_endpoint}/onedrive/connect"
-      GRAPH_NOTIFICATION_URL        = "${aws_apigatewayv2_api.petroglyph_api.api_endpoint}/onedrive/lifecycle"
+      GITHUB_REDIRECT_URI           = "${local.api_base_url}/auth/callback"
+      MICROSOFT_REDIRECT_URI        = "${local.api_base_url}/onedrive/connect"
+      GRAPH_NOTIFICATION_URL        = "${local.api_base_url}/onedrive/lifecycle"
       REFRESH_TOKENS_TABLE          = aws_dynamodb_table.refresh_tokens.name
       USERS_TABLE                   = aws_dynamodb_table.users.name
       SYNC_PROFILES_TABLE           = aws_dynamodb_table.sync_profiles.name


### PR DESCRIPTION
## Summary

Fixes a `redirect_uri_mismatch` error caused by OAuth redirect URIs being set to the raw `execute-api` endpoint instead of the registered custom domain.

### Changes

- **`packages/infra/custom_domain.tf`** — Added `api_base_url` local that resolves to `https://${var.api_custom_domain}` when a custom domain is set, otherwise falls back to the raw API endpoint.
- **`packages/infra/lambda_api.tf`** — Updated `MICROSOFT_REDIRECT_URI`, `GITHUB_REDIRECT_URI`, and `GRAPH_NOTIFICATION_URL` env vars to use `local.api_base_url` instead of the raw `api_endpoint`.
- **`docs/ops.md`** — Added note clarifying the required Azure app 'Supported account types' setting and the `unauthorized_client` error that results from an incorrect value.

### Acceptance criteria
After `terraform apply`, `MICROSOFT_REDIRECT_URI` on the Lambda equals `https://api.petroglyph.page/onedrive/connect`.

Closes petroglyph-v5n, petroglyph-hys