### PR TITLE
feat(plugin): refresh settings UI after auth callbacks

### DIFF
--- a/packages/api/scripts/package.test.ts
+++ b/packages/api/scripts/package.test.ts
@@ -30,7 +30,7 @@ describe("Lambda packaging smoke test", () => {
       cwd: apiDir,
       stdio: "inherit",
     });
-  });
+  }, 30_000);
 
   afterAll(() => {
     // Clean up test extraction
@@ -63,7 +63,7 @@ describe("Lambda packaging smoke test", () => {
 
     expect(module).toHaveProperty("handler");
     expect(typeof module.handler).toBe("function");
-  });
+  }, 15_000);
 
   it("handler export matches terraform config (dist/index.handler)", async () => {
     // This test documents that the Terraform config expects dist/index.handler

--- a/packages/infra/src/terraform-plan.test.ts
+++ b/packages/infra/src/terraform-plan.test.ts
@@ -75,7 +75,7 @@ describe.sequential("terraform ingestion infrastructure", () => {
     expect(outputsTerraform).toContain('output "ingest_queue_arn"');
     expect(outputsTerraform).toContain('output "ingest_dlq_url"');
     expect(outputsTerraform).toContain('output "ingest_dlq_arn"');
-  }, 60_000);
+  }, 120_000);
 
   it("connects the processor lambda to the ingest queue and exposes the webhook route", () => {
     runTerraformValidate();

--- a/packages/plugin/src/main.test.ts
+++ b/packages/plugin/src/main.test.ts
@@ -521,6 +521,9 @@ describe("handleOneDriveCallback", () => {
 
   it("sets oneDriveConnected=true and saves data on success", async () => {
     const { plugin } = await makePlugin({ jwt: "jwt-token", refreshToken: "r", username: "alice" });
+    const refreshSettingsUiSpy = vi
+      .spyOn(plugin, "refreshSettingsUi")
+      .mockImplementation(() => {});
 
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
 
@@ -531,6 +534,7 @@ describe("handleOneDriveCallback", () => {
     expect(plugin.saveData).toHaveBeenCalledWith(
       expect.objectContaining({ oneDriveConnected: true }),
     );
+    expect(refreshSettingsUiSpy).toHaveBeenCalledOnce();
   });
 
   it("calls POST /onedrive/connect with JWT Bearer and params", async () => {
@@ -602,6 +606,9 @@ describe("pollStatus", () => {
 
   it("updates oneDriveConnected from response and saves data", async () => {
     const { plugin } = await makePlugin({ jwt: "jwt-token", refreshToken: "r", username: "alice" });
+    const refreshSettingsUiSpy = vi
+      .spyOn(plugin, "refreshSettingsUi")
+      .mockImplementation(() => {});
 
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -615,6 +622,29 @@ describe("pollStatus", () => {
     expect(plugin.saveData).toHaveBeenCalledWith(
       expect.objectContaining({ oneDriveConnected: true }),
     );
+    expect(refreshSettingsUiSpy).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes settings when status polling updates oneDriveStatus", async () => {
+    const { plugin } = await makePlugin({
+      jwt: "jwt-token",
+      refreshToken: "r",
+      username: "alice",
+      oneDriveStatus: "ok",
+    });
+    const refreshSettingsUiSpy = vi
+      .spyOn(plugin, "refreshSettingsUi")
+      .mockImplementation(() => {});
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ oneDrive: { status: "reconnect_required" } }),
+    });
+
+    await plugin.pollStatus();
+
+    expect(plugin.data.oneDriveStatus).toBe("reconnect_required");
+    expect(refreshSettingsUiSpy).toHaveBeenCalledOnce();
   });
 
   it("does nothing when no JWT is stored", async () => {
@@ -763,6 +793,9 @@ describe("petroglyph/auth/callback URI handler", () => {
     const startStatusPollingSpy = vi
       .spyOn(plugin, "startStatusPolling")
       .mockImplementation(() => {});
+    const refreshSettingsUiSpy = vi
+      .spyOn(plugin, "refreshSettingsUi")
+      .mockImplementation(() => {});
 
     await plugin.onload();
 
@@ -786,6 +819,7 @@ describe("petroglyph/auth/callback URI handler", () => {
     expect(savePluginDataSpy).toHaveBeenCalledOnce();
     expect(scheduleRefreshSpy).toHaveBeenCalledWith("jwt-token");
     expect(startStatusPollingSpy).toHaveBeenCalledOnce();
+    expect(refreshSettingsUiSpy).toHaveBeenCalledOnce();
     expect(Notice).toHaveBeenCalledWith("Logged in as @alice");
   });
 

--- a/packages/plugin/src/main.test.ts
+++ b/packages/plugin/src/main.test.ts
@@ -521,9 +521,7 @@ describe("handleOneDriveCallback", () => {
 
   it("sets oneDriveConnected=true and saves data on success", async () => {
     const { plugin } = await makePlugin({ jwt: "jwt-token", refreshToken: "r", username: "alice" });
-    const refreshSettingsUiSpy = vi
-      .spyOn(plugin, "refreshSettingsUi")
-      .mockImplementation(() => {});
+    const refreshSettingsUiSpy = vi.spyOn(plugin, "refreshSettingsUi").mockImplementation(() => {});
 
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
 
@@ -606,9 +604,7 @@ describe("pollStatus", () => {
 
   it("updates oneDriveConnected from response and saves data", async () => {
     const { plugin } = await makePlugin({ jwt: "jwt-token", refreshToken: "r", username: "alice" });
-    const refreshSettingsUiSpy = vi
-      .spyOn(plugin, "refreshSettingsUi")
-      .mockImplementation(() => {});
+    const refreshSettingsUiSpy = vi.spyOn(plugin, "refreshSettingsUi").mockImplementation(() => {});
 
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -632,9 +628,7 @@ describe("pollStatus", () => {
       username: "alice",
       oneDriveStatus: "ok",
     });
-    const refreshSettingsUiSpy = vi
-      .spyOn(plugin, "refreshSettingsUi")
-      .mockImplementation(() => {});
+    const refreshSettingsUiSpy = vi.spyOn(plugin, "refreshSettingsUi").mockImplementation(() => {});
 
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -793,9 +787,7 @@ describe("petroglyph/auth/callback URI handler", () => {
     const startStatusPollingSpy = vi
       .spyOn(plugin, "startStatusPolling")
       .mockImplementation(() => {});
-    const refreshSettingsUiSpy = vi
-      .spyOn(plugin, "refreshSettingsUi")
-      .mockImplementation(() => {});
+    const refreshSettingsUiSpy = vi.spyOn(plugin, "refreshSettingsUi").mockImplementation(() => {});
 
     await plugin.onload();
 

--- a/packages/plugin/src/main.ts
+++ b/packages/plugin/src/main.ts
@@ -185,6 +185,7 @@ export class PetroglyphPlugin extends Plugin {
   private _refreshTimeoutId: number | null = null;
   private _statusPollIntervalId: number | null = null;
   private _syncPollIntervalId: number | null = null;
+  private _settingTab: PetroglyphSettingTab | null = null;
 
   get data(): Readonly<PluginData> {
     return this._data;
@@ -220,6 +221,10 @@ export class PetroglyphPlugin extends Plugin {
 
   setOneDriveConnected(connected: boolean): void {
     this._data = { ...this._data, oneDriveConnected: connected };
+  }
+
+  refreshSettingsUi(): void {
+    this._settingTab?.display();
   }
 
   startStatusPolling(): void {
@@ -375,7 +380,8 @@ export class PetroglyphPlugin extends Plugin {
     await this.loadPluginData();
     await this.loadProfiles();
 
-    this.addSettingTab(new PetroglyphSettingTab(this.app, this));
+    this._settingTab = new PetroglyphSettingTab(this.app, this);
+    this.addSettingTab(this._settingTab);
 
     // Register manual commands
     if (typeof this.addCommand === "function") {
@@ -415,6 +421,7 @@ export class PetroglyphPlugin extends Plugin {
       }
       this.setCredentials(jwt, refreshToken, username);
       await this.savePluginData();
+      this.refreshSettingsUi();
       this.scheduleRefresh(jwt);
       this.startStatusPolling();
       new Notice(`Logged in as @${username}`);
@@ -690,6 +697,7 @@ export class PetroglyphPlugin extends Plugin {
       }
       this.setOneDriveConnected(true);
       await this.savePluginData();
+      this.refreshSettingsUi();
       this.startSyncPolling();
       new Notice("OneDrive connected");
     } catch {
@@ -708,13 +716,24 @@ export class PetroglyphPlugin extends Plugin {
       if (!isRecord(body)) return;
       const oneDrive = body["oneDrive"];
       if (isRecord(oneDrive)) {
+        let stateChanged = false;
         if (typeof oneDrive["connected"] === "boolean") {
-          this.setOneDriveConnected(oneDrive["connected"]);
+          if (this._data.oneDriveConnected !== oneDrive["connected"]) {
+            this.setOneDriveConnected(oneDrive["connected"]);
+            stateChanged = true;
+          }
         }
         if (typeof oneDrive["status"] === "string") {
-          this._data = { ...this._data, oneDriveStatus: oneDrive["status"] };
+          if (this._data.oneDriveStatus !== oneDrive["status"]) {
+            this._data = { ...this._data, oneDriveStatus: oneDrive["status"] };
+            stateChanged = true;
+          }
+        }
+        if (!stateChanged) {
+          return;
         }
         await this.savePluginData();
+        this.refreshSettingsUi();
       }
     } catch {
       // Network errors are silently ignored; the next poll will retry.


### PR DESCRIPTION
Closes petroglyph-pu4

## Summary

The GitHub and OneDrive auth flows were saving new state but the Obsidian settings tab only reflected the change after the user left and reopened the pane.

## Changes

- Add `refreshSettingsUi()` to `PetroglyphPlugin`, guarded with optional chaining in case the settings tab is not yet initialised
- Call `refreshSettingsUi()` after GitHub auth URI handler saves credentials
- Call `refreshSettingsUi()` after OneDrive connect handler saves state
- Call `refreshSettingsUi()` in `pollStatus` only when state actually changes (avoids redundant saves and re-renders)
- Raise `terraform-plan.test.ts` timeout 60s → 120s for slow test
- Add scoped timeouts to `package.test.ts` (30s `beforeAll`, 15s import test)