### PR TITLE
chore: improve Graph subscription error logging

### DIFF
--- a/packages/api/src/onedrive-connect.test.ts
+++ b/packages/api/src/onedrive-connect.test.ts
@@ -93,6 +93,7 @@ function setupFetchMock(options: { msTokenOk?: boolean; graphOk?: boolean } = {}
         status: graphOk ? 201 : 500,
         statusText: graphOk ? "Created" : "Internal Server Error",
         json: () => Promise.resolve({ id: "sub-123" }),
+        text: () => Promise.resolve('{"error":"Invalid request"}'),
       } as Response);
     }
     return Promise.reject(new Error(`Unexpected fetch: ${url}`));

--- a/packages/api/src/onedrive-connect.ts
+++ b/packages/api/src/onedrive-connect.ts
@@ -171,8 +171,10 @@ async function registerGraphSubscription(accessToken: string, userId: string): P
   });
 
   if (!response.ok) {
+    const text = await response.text();
     console.warn(
       `[onedrive-connect] Graph subscription registration failed: ${response.status} ${response.statusText}`,
+      text,
     );
   }
 }


### PR DESCRIPTION
When Graph subscription registration fails, log the full error response body to help diagnose issues.

This is part of debugging why Graph subscriptions aren't being created on OneDrive connections (9jt.5).

## Changes
- Log response body when Graph subscription POST fails
- Update test mock to include text() method

All tests passing (178/178 in api package)