### PR TITLE
Fix OneDrive Graph subscription registration

### DIFF
--- a/packages/api/src/onedrive-connect.test.ts
+++ b/packages/api/src/onedrive-connect.test.ts
@@ -35,6 +35,7 @@ const VALID_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
 const MS_ACCESS_TOKEN = "ms-access-token-abc";
 const MS_REFRESH_TOKEN = "ms-refresh-token-def";
 const MS_EXPIRES_IN = 3600;
+const MS_DRIVE_ID = "drive-123";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -69,8 +70,10 @@ function setupDynamoMock(stateItem: object | undefined): void {
   });
 }
 
-function setupFetchMock(options: { msTokenOk?: boolean; graphOk?: boolean } = {}): void {
-  const { msTokenOk = true, graphOk = true } = options;
+function setupFetchMock(
+  options: { msTokenOk?: boolean; graphOk?: boolean; graphDriveOk?: boolean } = {},
+): void {
+  const { msTokenOk = true, graphOk = true, graphDriveOk = true } = options;
 
   mockFetch.mockImplementation((url: string) => {
     if (url === "https://login.microsoftonline.com/common/oauth2/v2.0/token") {
@@ -85,6 +88,20 @@ function setupFetchMock(options: { msTokenOk?: boolean; graphOk?: boolean } = {}
       return Promise.resolve({
         ok: true,
         json: () => Promise.resolve(makeMsTokenResponse()),
+      } as Response);
+    }
+    if (url === "https://graph.microsoft.com/v1.0/me/drive") {
+      if (!graphDriveOk) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          json: () => Promise.resolve({}),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ id: MS_DRIVE_ID }),
       } as Response);
     }
     if (url === "https://graph.microsoft.com/v1.0/subscriptions") {
@@ -131,6 +148,7 @@ describe("POST /onedrive/connect", () => {
     vi.stubEnv("MICROSOFT_CLIENT_SECRET", "test-ms-client-secret");
     vi.stubEnv("MICROSOFT_REDIRECT_URI", "obsidian://petroglyph/onedrive/callback");
     vi.stubEnv("GRAPH_NOTIFICATION_URL", "https://api.example.com/graph/notify");
+    vi.stubEnv("GRAPH_LIFECYCLE_URL", "https://api.example.com/graph/lifecycle");
     vi.stubEnv("SYNC_PROFILES_TABLE", "petroglyph-sync-profiles-test");
     vi.stubEnv("REFRESH_TOKENS_TABLE", "petroglyph-refresh_tokens-test");
     mockDbSend.mockClear();
@@ -337,13 +355,15 @@ describe("POST /onedrive/connect", () => {
     const sentBody = JSON.parse(options.body as string) as {
       changeType: string;
       notificationUrl: string;
+      lifecycleNotificationUrl?: string;
       resource: string;
       expirationDateTime: string;
       clientState: string;
     };
     expect(sentBody.changeType).toBe("updated");
     expect(sentBody.notificationUrl).toBe("https://api.example.com/graph/notify");
-    expect(sentBody.resource).toBe("/me/drive/root/children");
+    expect(sentBody.lifecycleNotificationUrl).toBe("https://api.example.com/graph/lifecycle");
+    expect(sentBody.resource).toBe(`/drives/${MS_DRIVE_ID}/root`);
     expect(sentBody.clientState).toBe(USER_ID);
 
     const expiryMs = new Date(sentBody.expirationDateTime).getTime();

--- a/packages/api/src/onedrive-connect.ts
+++ b/packages/api/src/onedrive-connect.ts
@@ -30,6 +30,10 @@ interface MicrosoftTokenResponse {
   expires_in: number;
 }
 
+interface GraphDriveResponse {
+  id: string;
+}
+
 class UpstreamError extends Error {
   constructor(message: string) {
     super(message);
@@ -56,6 +60,10 @@ const isMicrosoftTokenResponse = isObject<MicrosoftTokenResponse>({
   access_token: is("string"),
   refresh_token: is("string"),
   expires_in: is("number"),
+});
+
+const isGraphDriveResponse = isObject<GraphDriveResponse>({
+  id: is("string"),
 });
 
 function parseMicrosoftTokenResponse(data: unknown): MicrosoftTokenResponse {
@@ -122,6 +130,25 @@ async function exchangeCodeForTokens(
   return parseMicrosoftTokenResponse(await response.json());
 }
 
+async function fetchGraphDriveId(accessToken: string): Promise<string> {
+  const response = await fetch("https://graph.microsoft.com/v1.0/me/drive", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new UpstreamError(`Graph drive lookup failed: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  if (!isGraphDriveResponse(data)) {
+    throw new UpstreamError("Invalid Graph drive response shape");
+  }
+
+  return data.id;
+}
+
 async function storeTokensInDynamoDB(
   userId: string,
   accessToken: string,
@@ -147,9 +174,18 @@ async function storeTokensInDynamoDB(
 }
 
 async function registerGraphSubscription(accessToken: string, userId: string): Promise<void> {
-  const notificationUrl = process.env["GRAPH_NOTIFICATION_URL"];
+  const notificationUrl = process.env["GRAPH_NOTIFICATION_URL"]?.trim();
   if (!notificationUrl) {
     console.warn("[onedrive-connect] GRAPH_NOTIFICATION_URL not configured, skipping subscription");
+    return;
+  }
+
+  const lifecycleNotificationUrl = process.env["GRAPH_LIFECYCLE_URL"]?.trim();
+  let driveId: string;
+  try {
+    driveId = await fetchGraphDriveId(accessToken);
+  } catch (error) {
+    console.warn("[onedrive-connect] Graph drive lookup failed", error);
     return;
   }
 
@@ -158,19 +194,22 @@ async function registerGraphSubscription(accessToken: string, userId: string): P
     Date.now() + graphSubscriptionMaxMinutes * 60 * 1000,
   ).toISOString();
 
+  const requestBody = {
+    changeType: "updated",
+    notificationUrl,
+    resource: `/drives/${driveId}/root`,
+    expirationDateTime,
+    clientState: userId,
+    ...(lifecycleNotificationUrl ? { lifecycleNotificationUrl } : {}),
+  };
+
   const response = await fetch("https://graph.microsoft.com/v1.0/subscriptions", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${accessToken}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      changeType: "updated",
-      notificationUrl,
-      resource: "/me/drive/root/children",
-      expirationDateTime,
-      clientState: userId,
-    }),
+    body: JSON.stringify(requestBody),
   });
 
   if (!response.ok) {

--- a/packages/infra/lambda_api.tf
+++ b/packages/infra/lambda_api.tf
@@ -29,7 +29,8 @@ resource "aws_lambda_function" "petroglyph_api" {
       ONEDRIVE_CLIENT_SECRET_SSM_PATH = aws_ssm_parameter.onedrive_client_secret.name
       GITHUB_REDIRECT_URI            = "${local.api_base_url}/auth/callback"
       MICROSOFT_REDIRECT_URI         = "${local.api_base_url}/onedrive/connect"
-      GRAPH_NOTIFICATION_URL         = "${local.api_base_url}/onedrive/lifecycle"
+      GRAPH_NOTIFICATION_URL         = "${local.api_base_url}/webhooks/onedrive"
+      GRAPH_LIFECYCLE_URL            = "${local.api_base_url}/onedrive/lifecycle"
       REFRESH_TOKENS_TABLE           = aws_dynamodb_table.refresh_tokens.name
       USERS_TABLE                    = aws_dynamodb_table.users.name
       SYNC_PROFILES_TABLE            = aws_dynamodb_table.sync_profiles.name


### PR DESCRIPTION
## Summary
- fetch the OneDrive drive id before creating the Graph subscription and include the lifecycle URL when configured
- register change notifications against /drives/{id}/root and route them to the webhook ingest endpoint
- extend coverage for drive lookup and lifecycle URL in the connect tests

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm format