### PR TITLE
Deploy OneDrive webhook ingestion

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,10 +63,15 @@ jobs:
             packages/*/*.tsbuildinfo
           key: dist-${{ github.sha }}
       - run: pnpm --filter @petroglyph/api package
+      - run: pnpm --filter @petroglyph/ingest-onedrive package
       - uses: actions/upload-artifact@v4
         with:
           name: lambda-zip
           path: packages/api/lambda.zip
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ingest-onedrive-zip
+          path: packages/ingest-onedrive/lambda.zip
 
   deploy:
     needs: [package]
@@ -93,6 +98,10 @@ jobs:
         with:
           name: lambda-zip
           path: packages/api
+      - uses: actions/download-artifact@v4
+        with:
+          name: ingest-onedrive-zip
+          path: packages/ingest-onedrive
       - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -102,6 +111,11 @@ jobs:
         run: |
           HASH=$(sha256sum packages/api/lambda.zip | cut -d' ' -f1)
           echo "hash=$HASH" >> $GITHUB_OUTPUT
+      - name: Compute ingest lambda content hash
+        id: ingest-artifact-hash
+        run: |
+          HASH=$(sha256sum packages/ingest-onedrive/lambda.zip | cut -d' ' -f1)
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
       - name: Upload lambda zip to S3
         run: |
           KEY="lambda-${{ steps.artifact-hash.outputs.hash }}.zip"
@@ -109,6 +123,14 @@ jobs:
             echo "Artifact already exists at $KEY — skipping upload"
           else
             aws s3 cp packages/api/lambda.zip s3://${{ secrets.LAMBDA_ARTIFACT_BUCKET }}/$KEY
+          fi
+      - name: Upload ingest lambda zip to S3
+        run: |
+          KEY="ingest-onedrive-${{ steps.ingest-artifact-hash.outputs.hash }}.zip"
+          if aws s3api head-object --bucket ${{ secrets.LAMBDA_ARTIFACT_BUCKET }} --key "$KEY" 2>/dev/null; then
+            echo "Artifact already exists at $KEY — skipping upload"
+          else
+            aws s3 cp packages/ingest-onedrive/lambda.zip s3://${{ secrets.LAMBDA_ARTIFACT_BUCKET }}/$KEY
           fi
       - uses: hashicorp/setup-terraform@v4
       - name: Terraform init
@@ -130,6 +152,8 @@ jobs:
           terraform apply -auto-approve -refresh=false \
             -var="api_zip_s3_bucket=${{ secrets.LAMBDA_ARTIFACT_BUCKET }}" \
             -var="api_zip_s3_key=lambda-${{ steps.artifact-hash.outputs.hash }}.zip" \
+            -var="ingest_onedrive_zip_s3_bucket=${{ secrets.LAMBDA_ARTIFACT_BUCKET }}" \
+            -var="ingest_onedrive_zip_s3_key=ingest-onedrive-${{ steps.ingest-artifact-hash.outputs.hash }}.zip" \
             -var="api_custom_domain=api.petroglyph.page"
       - name: Capture API function URL
         id: api-function-url

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,7 @@ jobs:
             packages/*/dist
             packages/*/*.tsbuildinfo
           key: dist-${{ github.sha }}
-      - run: pnpm --filter @petroglyph/api package
-      - run: pnpm --filter @petroglyph/ingest-onedrive package
+      - run: pnpm package
       - uses: actions/upload-artifact@v4
         with:
           name: lambda-zip

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "pnpm -r run build",
     "dev": "pnpm -r --parallel run dev",
+    "package": "pnpm -r --parallel --if-present run package",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "pnpm -r run lint",

--- a/packages/infra/iam.tf
+++ b/packages/infra/iam.tf
@@ -77,6 +77,7 @@ resource "aws_iam_role_policy" "petroglyph_api_policy" {
           "${local.ssm_arn_prefix}/petroglyph/github/*",
           "${local.ssm_arn_prefix}/petroglyph/jwt/*",
           "${local.ssm_arn_prefix}/petroglyph/onedrive/*",
+          "${local.ssm_arn_prefix}/petroglyph/config/*",
         ]
       },
       {

--- a/packages/ingest-onedrive/package.json
+++ b/packages/ingest-onedrive/package.json
@@ -7,6 +7,7 @@
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -p tsconfig.build.json --watch",
     "lint": "eslint .",
+    "package": "bash scripts/package.sh",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/ingest-onedrive/scripts/package.sh
+++ b/packages/ingest-onedrive/scripts/package.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT="$PACKAGE_DIR/lambda.zip"
+
+echo "Building @petroglyph/ingest-onedrive..."
+pnpm build
+
+echo "Zipping to $OUTPUT..."
+rm -f "$OUTPUT"
+python3 -c "
+import zipfile, os, sys
+package_dir = sys.argv[1]
+output = sys.argv[2]
+with zipfile.ZipFile(output, 'w', zipfile.ZIP_DEFLATED) as zf:
+    zf.write(os.path.join(package_dir, 'dist', 'index.js'), 'dist/index.js')
+    zf.write(os.path.join(package_dir, 'package.json'), 'package.json')
+" "$PACKAGE_DIR" "$OUTPUT"
+
+echo "Done: $OUTPUT"

--- a/packages/ingest-onedrive/scripts/package.test.ts
+++ b/packages/ingest-onedrive/scripts/package.test.ts
@@ -1,0 +1,60 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const packageDir = join(__dirname, "..");
+const zipPath = join(packageDir, "lambda.zip");
+const extractDir = join(packageDir, ".test-extract");
+
+describe("Ingest OneDrive Lambda packaging smoke test", () => {
+  beforeAll(() => {
+    if (existsSync(extractDir)) {
+      rmSync(extractDir, { recursive: true, force: true });
+    }
+    mkdirSync(extractDir, { recursive: true });
+
+    console.log("Building Lambda package...");
+    execSync("pnpm package", {
+      cwd: packageDir,
+      stdio: "inherit",
+    });
+
+    console.log("Extracting Lambda zip...");
+    execSync(`unzip -q ${zipPath} -d ${extractDir}`, {
+      cwd: packageDir,
+      stdio: "inherit",
+    });
+  }, 60_000);
+
+  afterAll(() => {
+    if (existsSync(extractDir)) {
+      rmSync(extractDir, { recursive: true, force: true });
+    }
+  });
+
+  it("zip file exists", () => {
+    expect(existsSync(zipPath)).toBe(true);
+  });
+
+  it("contains dist/index.js", () => {
+    const indexPath = join(extractDir, "dist", "index.js");
+    expect(existsSync(indexPath)).toBe(true);
+  });
+
+  it("contains package.json", () => {
+    const pkgPath = join(extractDir, "package.json");
+    expect(existsSync(pkgPath)).toBe(true);
+  });
+
+  it("dist/index.js can be loaded by Node and exports handler", async () => {
+    const indexPath = join(extractDir, "dist", "index.js");
+    const indexUrl = new URL(`file://${indexPath}`);
+    const module = (await import(indexUrl.href)) as { handler?: unknown };
+
+    expect(module).toHaveProperty("handler");
+    expect(typeof module.handler).toBe("function");
+  }, 15_000);
+});

--- a/packages/ingest-onedrive/tsconfig.json
+++ b/packages/ingest-onedrive/tsconfig.json
@@ -4,5 +4,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["vitest.config.ts", "src/**/*"]
+  "include": ["vitest.config.ts", "src/**/*", "scripts/**/*"]
 }


### PR DESCRIPTION
## Summary
- package and deploy the ingest-onedrive Lambda in the Deploy workflow and wire it into Terraform
- add ingest-onedrive Lambda packaging script + smoke test
- allow API lambda to read /petroglyph/config/* SSM parameters for /files/changes

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm format