### PR TITLE
Bundle ingest-onedrive lambda

### DIFF
--- a/packages/ingest-onedrive/esbuild.config.mjs
+++ b/packages/ingest-onedrive/esbuild.config.mjs
@@ -1,0 +1,15 @@
+import esbuild from "esbuild";
+
+await esbuild.build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  format: "esm",
+  outfile: "dist/index.js",
+  platform: "node",
+  sourcemap: false,
+  target: "node24",
+  logLevel: "info",
+  banner: {
+    js: `import { createRequire } from "module"; const require = createRequire(import.meta.url);`,
+  },
+});

--- a/packages/ingest-onedrive/package.json
+++ b/packages/ingest-onedrive/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "node esbuild.config.mjs",
     "dev": "tsc -p tsconfig.build.json --watch",
     "lint": "eslint .",
     "package": "bash scripts/package.sh",
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.145",
-    "@types/node": "^25.5.2"
+    "@types/node": "^25.5.2",
+    "esbuild": "^0.28.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@types/node':
         specifier: ^25.5.2
         version: 25.5.2
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
 
   packages/plugin:
     devDependencies:


### PR DESCRIPTION
## Summary
- bundle ingest-onedrive with esbuild so runtime dependencies (zod, aws-sdk) are packaged
- update ingest-onedrive build script and lockfile

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm format