### PR TITLE
Add GET route for OneDrive webhook

### DIFF
--- a/packages/infra/lambda_ingestion.tf
+++ b/packages/infra/lambda_ingestion.tf
@@ -89,6 +89,14 @@ resource "aws_apigatewayv2_route" "onedrive_webhook_post" {
   target    = "integrations/${aws_apigatewayv2_integration.petroglyph_ingest_onedrive[0].id}"
 }
 
+resource "aws_apigatewayv2_route" "onedrive_webhook_get" {
+  count = var.ingest_onedrive_zip_s3_bucket != "" ? 1 : 0
+
+  api_id    = aws_apigatewayv2_api.petroglyph_api.id
+  route_key = "GET /webhooks/onedrive"
+  target    = "integrations/${aws_apigatewayv2_integration.petroglyph_ingest_onedrive[0].id}"
+}
+
 resource "aws_lambda_permission" "api_gateway_ingest_onedrive" {
   count = var.ingest_onedrive_zip_s3_bucket != "" ? 1 : 0
 

--- a/packages/infra/src/terraform-plan.test.ts
+++ b/packages/infra/src/terraform-plan.test.ts
@@ -90,6 +90,7 @@ describe.sequential("terraform ingestion infrastructure", () => {
       /resource "aws_lambda_event_source_mapping" "processor_ingest_queue" \{[\s\S]*event_source_arn\s*=\s*aws_sqs_queue\.ingest\.arn[\s\S]*function_name\s*=\s*aws_lambda_function\.petroglyph_processor\[0\]\.arn[\s\S]*batch_size\s*=\s*10/,
     );
     expect(lambdaIngestionTerraform).toContain('route_key = "POST /webhooks/onedrive"');
+    expect(lambdaIngestionTerraform).toContain('route_key = "GET /webhooks/onedrive"');
     expect(lambdaIngestionTerraform).toContain(
       'source_arn    = "${aws_apigatewayv2_api.petroglyph_api.execution_arn}/*/*/webhooks/onedrive"',
     );


### PR DESCRIPTION
## Summary
- add GET /webhooks/onedrive API Gateway route so Graph validation requests reach the ingest Lambda
- update Terraform plan test coverage for the GET webhook route

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test