### PR TITLE
fix(api): await lifecycle processing before returning 202

### DIFF
--- a/packages/api/src/onedrive-connect.ts
+++ b/packages/api/src/onedrive-connect.ts
@@ -202,6 +202,12 @@ async function registerGraphSubscription(accessToken: string, userId: string): P
     clientState: userId,
     ...(lifecycleNotificationUrl ? { lifecycleNotificationUrl } : {}),
   };
+  console.info("[onedrive-connect] Registering Graph subscription", {
+    notificationUrl,
+    resource: requestBody.resource,
+    expirationDateTime,
+    lifecycleNotificationUrl: lifecycleNotificationUrl ?? null,
+  });
 
   const response = await fetch("https://graph.microsoft.com/v1.0/subscriptions", {
     method: "POST",
@@ -218,7 +224,11 @@ async function registerGraphSubscription(accessToken: string, userId: string): P
       `[onedrive-connect] Graph subscription registration failed: ${response.status} ${response.statusText}`,
       text,
     );
+    return;
   }
+  console.info("[onedrive-connect] Graph subscription created", {
+    status: response.status,
+  });
 }
 
 async function upsertSyncProfile(userId: string): Promise<void> {
@@ -262,15 +272,24 @@ export async function handleOnedriveConnect(
   const body = parseConnectBody(rawBody);
 
   if (!body) {
+    console.warn("[onedrive-connect] Missing code/state in request body");
     return c.json({ error: "Missing required fields: code and state" }, 400);
   }
 
   const { code, state } = body;
+  const userId = c.get("userId");
+  console.info("[onedrive-connect] Starting connect flow", { userId });
 
   const stateItem = await lookupStateItem(state);
   const now = Math.floor(Date.now() / 1000);
 
   if (!stateItem || stateItem.type !== "onedrive_state" || stateItem.ttl < now) {
+    console.warn("[onedrive-connect] Invalid or expired state", {
+      userId,
+      stateType: stateItem?.type ?? null,
+      stateExpiry: stateItem?.ttl ?? null,
+      now,
+    });
     return c.json({ error: "Invalid or expired state" }, 401);
   }
 
@@ -281,15 +300,21 @@ export async function handleOnedriveConnect(
     tokens = await exchangeCodeForTokens(code, stateItem.verifier);
   } catch (err) {
     if (err instanceof UpstreamError) {
+      console.warn("[onedrive-connect] Microsoft token exchange failed", {
+        userId,
+        message: err.message,
+      });
       return c.json({ error: "Microsoft token exchange failed" }, 502);
     }
     throw err;
   }
 
-  const userId = c.get("userId");
+  console.info("[onedrive-connect] Microsoft token exchange succeeded", { userId });
   await storeTokensInDynamoDB(userId, tokens.access_token, tokens.refresh_token, tokens.expires_in);
+  console.info("[onedrive-connect] Stored Microsoft tokens in DynamoDB", { userId });
   await registerGraphSubscription(tokens.access_token, userId);
   await upsertSyncProfile(userId);
+  console.info("[onedrive-connect] OneDrive profile updated", { userId });
 
   return c.json({ status: "connected" });
 }

--- a/packages/api/src/onedrive-lifecycle.test.ts
+++ b/packages/api/src/onedrive-lifecycle.test.ts
@@ -306,61 +306,28 @@ describe("POST /onedrive/lifecycle", () => {
     expect(updateCommand.input.ExpressionAttributeValues[":status"]).toBe("reconnect_required");
   });
 
-  it("returns 202 before subscriptionRemoved work finishes", async () => {
-    let resolveUpdate: (() => void) | undefined;
-    mockDbSend.mockImplementation((command: unknown) => {
-      if (command instanceof UpdateCommand) {
-        return new Promise((resolve) => {
-          resolveUpdate = () => {
-            resolve({});
-          };
-        });
-      }
+  it("returns 202 after subscriptionRemoved work finishes", async () => {
+    mockDbSend.mockResolvedValue({});
 
-      return Promise.resolve({});
-    });
-
-    const requestPromise: Promise<Response> = Promise.resolve(
-      app.request("/onedrive/lifecycle", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          value: [
-            {
-              lifecycleEvent: "subscriptionRemoved",
-              clientState: "user-789",
-            },
-          ],
-        }),
+    const response = await app.request("/onedrive/lifecycle", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        value: [
+          {
+            lifecycleEvent: "subscriptionRemoved",
+            clientState: "user-789",
+          },
+        ],
       }),
-    );
-
-    const response = await Promise.race([
-      requestPromise.then(() => "response" as const),
-      new Promise<"timeout">((resolve) => {
-        setTimeout(() => {
-          resolve("timeout");
-        }, 20);
-      }),
-    ]);
-
-    expect(response).toBe("response");
-    await vi.waitFor(() => {
-      expect(resolveUpdate).toBeTypeOf("function");
     });
-    resolveUpdate?.();
 
-    const completedResponse = await requestPromise;
-    expect(completedResponse.status).toBe(202);
-
-    await vi.waitFor(() => {
-      expect(updateCalls()).toHaveLength(1);
-    });
+    expect(response.status).toBe(202);
+    expect(updateCalls()).toHaveLength(1);
   });
 
-  it("returns 202 before reauthorization work finishes", async () => {
+  it("returns 202 after reauthorization work finishes", async () => {
     setupSsmMock(new Date(Date.now() + 5 * 60 * 1000).toISOString());
-    let resolveRenewal: (() => void) | undefined;
     mockFetch.mockImplementation((url: string) => {
       if (url === "https://login.microsoftonline.com/common/oauth2/v2.0/token") {
         return Promise.resolve({
@@ -374,66 +341,41 @@ describe("POST /onedrive/lifecycle", () => {
         } as Response);
       }
       if (url === "https://graph.microsoft.com/v1.0/subscriptions/sub-123") {
-        return new Promise((resolve) => {
-          resolveRenewal = () => {
-            resolve({
-              ok: true,
-              json: () =>
-                Promise.resolve({
-                  id: "sub-123",
-                  expirationDateTime: "2026-04-14T00:00:00.000Z",
-                }),
-            } as Response);
-          };
-        });
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              id: "sub-123",
+              expirationDateTime: "2026-04-14T00:00:00.000Z",
+            }),
+        } as Response);
       }
       return Promise.reject(new Error(`Unexpected fetch: ${url}`));
     });
 
-    const requestPromise: Promise<Response> = Promise.resolve(
-      app.request("/onedrive/lifecycle", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          value: [
-            {
-              lifecycleEvent: "reauthorizationRequired",
-              clientState: "user-123",
-              subscriptionId: "sub-123",
-            },
-          ],
-        }),
+    const response = await app.request("/onedrive/lifecycle", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        value: [
+          {
+            lifecycleEvent: "reauthorizationRequired",
+            clientState: "user-123",
+            subscriptionId: "sub-123",
+          },
+        ],
       }),
-    );
-
-    const response = await Promise.race([
-      requestPromise.then(() => "response" as const),
-      new Promise<"timeout">((resolve) => {
-        setTimeout(() => {
-          resolve("timeout");
-        }, 20);
-      }),
-    ]);
-
-    expect(response).toBe("response");
-    await vi.waitFor(() => {
-      expect(resolveRenewal).toBeTypeOf("function");
     });
-    resolveRenewal?.();
 
-    const completedResponse = await requestPromise;
-    expect(completedResponse.status).toBe(202);
-
-    await vi.waitFor(() => {
-      expect(updateCalls()).toHaveLength(1);
-      expect(
-        putParameterCalls().some(
-          ([command]) =>
-            (command as { input: { Name: string } }).input.Name ===
-            "/petroglyph/onedrive/subscription-expiry",
-        ),
-      ).toBe(true);
-    });
+    expect(response.status).toBe(202);
+    expect(updateCalls()).toHaveLength(1);
+    expect(
+      putParameterCalls().some(
+        ([command]) =>
+          (command as { input: { Name: string } }).input.Name ===
+          "/petroglyph/onedrive/subscription-expiry",
+      ),
+    ).toBe(true);
   });
 
   it("returns 202 after lifecycle processing succeeds", async () => {

--- a/packages/api/src/onedrive-lifecycle.ts
+++ b/packages/api/src/onedrive-lifecycle.ts
@@ -150,14 +150,6 @@ async function processLifecycleNotifications(
   );
 }
 
-function dispatchLifecycleNotifications(notifications: LifecycleNotification[]): void {
-  queueMicrotask(() => {
-    void processLifecycleNotifications(notifications).catch((error: unknown) => {
-      console.error("[onedrive-lifecycle] lifecycle processing failed:", error);
-    });
-  });
-}
-
 export async function handleOnedriveLifecycle(c: Context): Promise<Response> {
   const validationToken = c.req.query("validationToken");
   if (validationToken) {
@@ -168,7 +160,9 @@ export async function handleOnedriveLifecycle(c: Context): Promise<Response> {
   }
 
   const notifications = parseLifecycleNotifications(await c.req.json().catch(() => null));
-  dispatchLifecycleNotifications(notifications);
+  await processLifecycleNotifications(notifications).catch((error: unknown) => {
+    console.error("[onedrive-lifecycle] lifecycle processing failed:", error);
+  });
 
   return c.body(null, 202);
 }


### PR DESCRIPTION
## Problem

`queueMicrotask` fire-and-forget is unreliable in Lambda. Once the HTTP response is sent the execution context can freeze, preventing pending I/O (token refresh, Graph PATCH, DynamoDB update) from completing. `reauthorizationRequired` processing was being silently dropped.

## Fix

Await `processLifecycleNotifications` inline so Lambda keeps running until the work is done. Graph accepts a few-second delay on the 202 response.

Removes the now-unnecessary `dispatchLifecycleNotifications` wrapper. Updates the two tests that asserted the old fire-and-forget behaviour to assert the new synchronous contract instead.