### PR TITLE
chore(infra): replace static IAM users with SSO profiles in bootstrap

### DIFF
--- a/packages/infra/scripts/bootstrap.sh
+++ b/packages/infra/scripts/bootstrap.sh
@@ -426,134 +426,6 @@ else
   success "Managed policy attached"
 fi
 
-# ── Step 7: petroglyph-admin IAM user ────────────────────────────────────────
-#
-# A scoped admin user for running terraform apply locally. Attach the same
-# deploy policy as the GitHub Actions role so local and CI have identical
-# permissions.
-
-ADMIN_USER="petroglyph-admin"
-
-info "Checking IAM user ($ADMIN_USER)..."
-if $AWS iam get-user --user-name "$ADMIN_USER" &>/dev/null; then
-  success "User $ADMIN_USER already exists"
-else
-  info "Creating IAM user $ADMIN_USER..."
-  $AWS iam create-user --user-name "$ADMIN_USER" \
-    --tags Key=purpose,Value=local-admin
-  success "User $ADMIN_USER created"
-fi
-
-info "Checking $DEPLOY_POLICY_NAME is attached to $ADMIN_USER..."
-if $AWS iam list-attached-user-policies --user-name "$ADMIN_USER" \
-    --query "AttachedPolicies[?PolicyArn=='${POLICY_ARN}']" --output text | grep -q .; then
-  success "Deploy policy already attached to $ADMIN_USER"
-else
-  info "Attaching deploy policy to $ADMIN_USER..."
-  $AWS iam attach-user-policy \
-    --user-name "$ADMIN_USER" \
-    --policy-arn "$POLICY_ARN"
-  success "Deploy policy attached to $ADMIN_USER"
-fi
-
-# ── Step 8: petroglyph-readonly IAM user ─────────────────────────────────────
-#
-# A read-only user for local developer machines and AI agents. Can read logs,
-# DynamoDB, SSM parameters, and Lambda config but cannot mutate anything.
-# Use the petroglyph-readonly profile for day-to-day work instead of admin.
-
-READONLY_USER="petroglyph-readonly"
-READONLY_POLICY_NAME="petroglyph-readonly"
-READONLY_POLICY_ARN="arn:aws:iam::${ACCOUNT_ID}:policy/${READONLY_POLICY_NAME}"
-READONLY_POLICY_DOC=$(cat << EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "DynamoDBRead",
-      "Effect": "Allow",
-      "Action": [
-        "dynamodb:GetItem",
-        "dynamodb:Query",
-        "dynamodb:Scan",
-        "dynamodb:DescribeTable",
-        "dynamodb:ListTables"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "SSMRead",
-      "Effect": "Allow",
-      "Action": [
-        "ssm:GetParameter",
-        "ssm:GetParameters",
-        "ssm:GetParametersByPath",
-        "ssm:DescribeParameters"
-      ],
-      "Resource": "arn:aws:ssm:${REGION}:${ACCOUNT_ID}:parameter/petroglyph/*"
-    },
-    {
-      "Sid": "LambdaRead",
-      "Effect": "Allow",
-      "Action": [
-        "lambda:GetFunction",
-        "lambda:GetFunctionConfiguration",
-        "lambda:ListFunctions",
-        "lambda:ListVersionsByFunction"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "CloudWatchLogsRead",
-      "Effect": "Allow",
-      "Action": [
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams",
-        "logs:FilterLogEvents",
-        "logs:GetLogEvents",
-        "logs:StartQuery",
-        "logs:GetQueryResults"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-)
-
-info "Checking readonly managed policy ($READONLY_POLICY_NAME)..."
-if $AWS iam get-policy --policy-arn "$READONLY_POLICY_ARN" &>/dev/null; then
-  success "Readonly policy already exists"
-else
-  info "Creating readonly managed policy..."
-  $AWS iam create-policy \
-    --policy-name "$READONLY_POLICY_NAME" \
-    --policy-document "$READONLY_POLICY_DOC"
-  success "Readonly policy created"
-fi
-
-info "Checking IAM user ($READONLY_USER)..."
-if $AWS iam get-user --user-name "$READONLY_USER" &>/dev/null; then
-  success "User $READONLY_USER already exists"
-else
-  info "Creating IAM user $READONLY_USER..."
-  $AWS iam create-user --user-name "$READONLY_USER" \
-    --tags Key=purpose,Value=local-readonly
-  success "User $READONLY_USER created"
-fi
-
-info "Checking readonly policy is attached to $READONLY_USER..."
-if $AWS iam list-attached-user-policies --user-name "$READONLY_USER" \
-    --query "AttachedPolicies[?PolicyArn=='${READONLY_POLICY_ARN}']" --output text | grep -q .; then
-  success "Readonly policy already attached to $READONLY_USER"
-else
-  info "Attaching readonly policy to $READONLY_USER..."
-  $AWS iam attach-user-policy \
-    --user-name "$READONLY_USER" \
-    --policy-arn "$READONLY_POLICY_ARN"
-  success "Readonly policy attached to $READONLY_USER"
-fi
-
 # ── Done ──────────────────────────────────────────────────────────────────────
 
 echo ""
@@ -569,25 +441,26 @@ echo "    AWS_ROLE_ARN           = arn:aws:iam::${ACCOUNT_ID}:role/${GITHUB_ACTI
 echo "    TF_STATE_BUCKET        = $TF_STATE_BUCKET"
 echo "    LAMBDA_ARTIFACT_BUCKET = $LAMBDA_ARTIFACT_BUCKET"
 echo ""
-echo "  Create access keys for local profiles in IAM console:"
-echo "    petroglyph-admin    → IAM > Users > petroglyph-admin > Security credentials"
-echo "    petroglyph-readonly → IAM > Users > petroglyph-readonly > Security credentials"
-echo ""
-echo "  Add to ~/.aws/credentials:"
-echo "    [petroglyph-admin]"
-echo "    aws_access_key_id     = <key>"
-echo "    aws_secret_access_key = <secret>"
-echo ""
-echo "    [petroglyph-readonly]"
-echo "    aws_access_key_id     = <key>"
-echo "    aws_secret_access_key = <secret>"
+echo "  Local AWS profiles use IAM Identity Center (SSO)."
+echo "  Run 'aws sso login --profile petroglyph-admin' to authenticate."
 echo ""
 echo "  Add to ~/.aws/config:"
+echo "    [sso-session petroglyph]"
+echo "    sso_start_url          = https://d-9c674d4043.awsapps.com/start"
+echo "    sso_region             = $REGION"
+echo "    sso_registration_scopes = sso:account:access"
+echo ""
 echo "    [profile petroglyph-admin]"
-echo "    region = $REGION"
+echo "    sso_session            = petroglyph"
+echo "    sso_account_id         = $ACCOUNT_ID"
+echo "    sso_role_name          = AdministratorAccess"
+echo "    region                 = $REGION"
 echo ""
 echo "    [profile petroglyph-readonly]"
-echo "    region = $REGION"
+echo "    sso_session            = petroglyph"
+echo "    sso_account_id         = $ACCOUNT_ID"
+echo "    sso_role_name          = petroglyph-readonly"
+echo "    region                 = $REGION"
 echo ""
 echo "  Use petroglyph-readonly for day-to-day work."
 echo "  Use petroglyph-admin only for terraform apply."


### PR DESCRIPTION
Local AWS access now uses IAM Identity Center SSO instead of static access keys.

## Changes
- Remove Steps 7 & 8 from `bootstrap.sh` (static `petroglyph-admin` and `petroglyph-readonly` IAM user creation)
- Update bootstrap summary to show SSO-based `~/.aws/config` snippet
- The `petroglyph-readonly` SSO permission set has been created in IAM Identity Center with CloudWatch, DynamoDB, SSM, and Lambda read-only access
- `petroglyph-admin` continues to use the existing `AdministratorAccess` SSO permission set

## No action needed post-merge
The SSO permission set and account assignment are already live. Existing `~/.aws/config` has been updated locally.