### PR TITLE
fix(api): always force token refresh on reauthorizationRequired

### DIFF
--- a/packages/api/src/onedrive-lifecycle.test.ts
+++ b/packages/api/src/onedrive-lifecycle.test.ts
@@ -116,8 +116,8 @@ describe("POST /onedrive/lifecycle", () => {
     expect(updateCommand.input.ExpressionAttributeValues[":status"]).toBe("reconnect_required");
   });
 
-  it("refreshes and renews subscriptions for reauthorizationRequired events", async () => {
-    setupSsmMock(new Date(Date.now() + 5 * 60 * 1000).toISOString());
+  it("refreshes the token and renews the subscription for reauthorizationRequired events", async () => {
+    setupSsmMock(new Date(Date.now() + 60 * 60 * 1000).toISOString()); // 1 hour — well outside the refresh window
     mockFetch.mockImplementation((url: string) => {
       if (url === "https://login.microsoftonline.com/common/oauth2/v2.0/token") {
         return Promise.resolve({
@@ -215,7 +215,7 @@ describe("POST /onedrive/lifecycle", () => {
   });
 
   it("marks the user as reconnect_required when token refresh fails", async () => {
-    setupSsmMock(new Date(Date.now() + 5 * 60 * 1000).toISOString());
+    setupSsmMock(new Date(Date.now() + 60 * 60 * 1000).toISOString()); // 1 hour — well outside the refresh window
     mockFetch.mockResolvedValue({
       ok: false,
       status: 401,

--- a/packages/api/src/onedrive-lifecycle.ts
+++ b/packages/api/src/onedrive-lifecycle.ts
@@ -2,7 +2,7 @@ import { PutParameterCommand } from "@aws-sdk/client-ssm";
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { Context } from "hono";
 import { docClient } from "./db.js";
-import { resolveOneDriveAccessToken } from "./onedrive-middleware.js";
+import { readOneDriveParams, refreshOneDriveToken } from "./onedrive-middleware.js";
 import { ssmClient } from "./ssm.js";
 
 function usersTable(): string {
@@ -120,7 +120,8 @@ async function handleReauthorizationRequired(notification: LifecycleNotification
     throw new Error("Lifecycle notification missing subscriptionId");
   }
 
-  const accessToken = await resolveOneDriveAccessToken();
+  const { refreshToken } = await readOneDriveParams();
+  const accessToken = await refreshOneDriveToken(refreshToken);
   const subscriptionExpiry = await renewGraphSubscription(notification.subscriptionId, accessToken);
   await storeSubscriptionExpiry(subscriptionExpiry);
   await markConnected(notification.clientState);


### PR DESCRIPTION
## Problem

`handleReauthorizationRequired` called `resolveOneDriveAccessToken`, which only refreshes the token when the stored `tokenExpiry` is within 10 minutes. If the access token is stale (revoked, or the stored expiry is wrong), it returns the old token and the Graph PATCH gets a `401 Unauthorized`.

## Fix

When handling `reauthorizationRequired`, always force a token refresh via `refreshOneDriveToken`. The event itself is Graph saying _"please reauthorize"_ — so we should always refresh, not rely on the lazy expiry heuristic.

## Verified

- All 178 tests pass
- CloudWatch confirmed the 401 path: handler ran after PR #70 merged, but stale token caused Graph PATCH to fail