### PR TITLE
fix(api): use user refresh token for lifecycle reauthorization

### DIFF
--- a/packages/api/src/onedrive-lifecycle.test.ts
+++ b/packages/api/src/onedrive-lifecycle.test.ts
@@ -1,5 +1,5 @@
-import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
-import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockDbSend = vi.hoisted(() => vi.fn());
@@ -25,7 +25,9 @@ describe("POST /onedrive/lifecycle", () => {
     mockSsmSend.mockReset();
     mockFetch.mockReset();
     vi.stubEnv("USERS_TABLE", "petroglyph-users-test");
+    vi.stubEnv("REFRESH_TOKENS_TABLE", "petroglyph-refresh_tokens-test");
     vi.stubEnv("MICROSOFT_CLIENT_ID", "test-ms-client-id");
+    vi.stubEnv("MICROSOFT_CLIENT_SECRET", "test-ms-client-secret");
   });
 
   afterEach(() => {
@@ -33,24 +35,22 @@ describe("POST /onedrive/lifecycle", () => {
     vi.restoreAllMocks();
   });
 
-  function setupSsmMock(tokenExpiry: string): void {
+  interface CommandResponseEntry {
+    command: new (...args: never[]) => object;
+    response: unknown;
+  }
+
+  function setupDbMock(entries: CommandResponseEntry[]): void {
+    mockDbSend.mockImplementation((command: unknown) => {
+      const match = entries.find((entry) => command instanceof entry.command);
+      return Promise.resolve(match?.response ?? {});
+    });
+  }
+
+  function setupSsmMock(entries: CommandResponseEntry[]): void {
     mockSsmSend.mockImplementation((command: unknown) => {
-      if (command instanceof GetParameterCommand) {
-        const name = (command as { input: { Name: string } }).input.Name;
-        if (name === "/petroglyph/onedrive/access-token") {
-          return Promise.resolve({ Parameter: { Value: "existing-access-token" } });
-        }
-        if (name === "/petroglyph/onedrive/token-expiry") {
-          return Promise.resolve({ Parameter: { Value: tokenExpiry } });
-        }
-        if (name === "/petroglyph/onedrive/refresh-token") {
-          return Promise.resolve({ Parameter: { Value: "existing-refresh-token" } });
-        }
-      }
-      if (command instanceof PutParameterCommand) {
-        return Promise.resolve({});
-      }
-      return Promise.resolve({});
+      const match = entries.find((entry) => command instanceof entry.command);
+      return Promise.resolve(match?.response ?? {});
     });
   }
 
@@ -117,7 +117,10 @@ describe("POST /onedrive/lifecycle", () => {
   });
 
   it("refreshes the token and renews the subscription for reauthorizationRequired events", async () => {
-    setupSsmMock(new Date(Date.now() + 60 * 60 * 1000).toISOString()); // 1 hour — well outside the refresh window
+    setupDbMock([
+      { command: GetCommand, response: { Item: { refreshToken: "existing-refresh-token" } } },
+    ]);
+    setupSsmMock([{ command: PutParameterCommand, response: {} }]);
     mockFetch.mockImplementation((url: string) => {
       if (url === "https://login.microsoftonline.com/common/oauth2/v2.0/token") {
         return Promise.resolve({
@@ -215,7 +218,10 @@ describe("POST /onedrive/lifecycle", () => {
   });
 
   it("marks the user as reconnect_required when token refresh fails", async () => {
-    setupSsmMock(new Date(Date.now() + 60 * 60 * 1000).toISOString()); // 1 hour — well outside the refresh window
+    setupDbMock([
+      { command: GetCommand, response: { Item: { refreshToken: "existing-refresh-token" } } },
+    ]);
+    setupSsmMock([{ command: PutParameterCommand, response: {} }]);
     mockFetch.mockResolvedValue({
       ok: false,
       status: 401,
@@ -261,7 +267,10 @@ describe("POST /onedrive/lifecycle", () => {
   });
 
   it("marks the user as reconnect_required when subscription renewal fails", async () => {
-    setupSsmMock(new Date(Date.now() + 30 * 60 * 1000).toISOString());
+    setupDbMock([
+      { command: GetCommand, response: { Item: { refreshToken: "existing-refresh-token" } } },
+    ]);
+    setupSsmMock([{ command: PutParameterCommand, response: {} }]);
     mockFetch.mockResolvedValue({
       ok: false,
       status: 500,
@@ -327,7 +336,10 @@ describe("POST /onedrive/lifecycle", () => {
   });
 
   it("returns 202 after reauthorization work finishes", async () => {
-    setupSsmMock(new Date(Date.now() + 5 * 60 * 1000).toISOString());
+    setupDbMock([
+      { command: GetCommand, response: { Item: { refreshToken: "existing-refresh-token" } } },
+    ]);
+    setupSsmMock([{ command: PutParameterCommand, response: {} }]);
     mockFetch.mockImplementation((url: string) => {
       if (url === "https://login.microsoftonline.com/common/oauth2/v2.0/token") {
         return Promise.resolve({

--- a/packages/api/src/onedrive-lifecycle.ts
+++ b/packages/api/src/onedrive-lifecycle.ts
@@ -1,12 +1,16 @@
 import { PutParameterCommand } from "@aws-sdk/client-ssm";
-import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { Context } from "hono";
 import { docClient } from "./db.js";
-import { readOneDriveParams, refreshOneDriveToken } from "./onedrive-middleware.js";
+import { refreshOneDriveToken } from "./onedrive-middleware.js";
 import { ssmClient } from "./ssm.js";
 
 function usersTable(): string {
   return process.env["USERS_TABLE"] ?? "petroglyph-users-default";
+}
+
+function refreshTokensTable(): string {
+  return process.env["REFRESH_TOKENS_TABLE"] ?? "petroglyph-refresh_tokens-default";
 }
 
 interface LifecycleNotification {
@@ -19,6 +23,17 @@ type OneDriveStatus = "connected" | "reconnect_required";
 
 function isRecord(value: unknown): value is { [key: string]: unknown } {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseRefreshToken(item: unknown, userId: string): string {
+  if (
+    !isRecord(item) ||
+    typeof item["refreshToken"] !== "string" ||
+    item["refreshToken"].length === 0
+  ) {
+    throw new Error(`Refresh token missing for user ${userId}`);
+  }
+  return item["refreshToken"];
 }
 
 function parseLifecycleNotifications(body: unknown): LifecycleNotification[] {
@@ -120,7 +135,17 @@ async function handleReauthorizationRequired(notification: LifecycleNotification
     throw new Error("Lifecycle notification missing subscriptionId");
   }
 
-  const { refreshToken } = await readOneDriveParams();
+  const refreshTokenResult = await docClient.send(
+    new GetCommand({
+      TableName: refreshTokensTable(),
+      Key: { tokenHash: notification.clientState },
+    }),
+  );
+  const refreshToken = parseRefreshToken(
+    refreshTokenResult.Item as unknown,
+    notification.clientState,
+  );
+
   const accessToken = await refreshOneDriveToken(refreshToken);
   const subscriptionExpiry = await renewGraphSubscription(notification.subscriptionId, accessToken);
   await storeSubscriptionExpiry(subscriptionExpiry);

--- a/packages/api/src/onedrive-middleware.test.ts
+++ b/packages/api/src/onedrive-middleware.test.ts
@@ -87,6 +87,7 @@ describe("onedriveMiddleware", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", mockFetch);
     vi.stubEnv("MICROSOFT_CLIENT_ID", "test-client-id");
+    vi.stubEnv("MICROSOFT_CLIENT_SECRET", "test-client-secret");
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -145,6 +146,7 @@ describe("onedriveMiddleware", () => {
 
       const params = new URLSearchParams(init.body);
       expect(params.get("client_id")).toBe("test-client-id");
+      expect(params.get("client_secret")).toBe("test-client-secret");
       expect(params.get("grant_type")).toBe("refresh_token");
       expect(params.get("refresh_token")).toBe(REFRESH_TOKEN);
       expect(params.get("scope")).toBe("files.read offline_access");

--- a/packages/api/src/onedrive-middleware.ts
+++ b/packages/api/src/onedrive-middleware.ts
@@ -58,9 +58,12 @@ function assertMicrosoftTokenResponse(value: unknown): asserts value is Microsof
 export async function refreshOneDriveToken(currentRefreshToken: string): Promise<string> {
   const clientId = process.env["MICROSOFT_CLIENT_ID"];
   if (!clientId) throw new Error("MICROSOFT_CLIENT_ID env var not set");
+  const clientSecret = process.env["MICROSOFT_CLIENT_SECRET"];
+  if (!clientSecret) throw new Error("MICROSOFT_CLIENT_SECRET env var not set");
 
   const body = new URLSearchParams({
     client_id: clientId,
+    client_secret: clientSecret,
     grant_type: "refresh_token",
     refresh_token: currentRefreshToken,
     scope: "files.read offline_access",

--- a/packages/api/src/sync-run.test.ts
+++ b/packages/api/src/sync-run.test.ts
@@ -38,6 +38,7 @@ describe("POST /sync/run", () => {
     vi.stubEnv("ONEDRIVE_FOLDER", "OnyxBoox");
     vi.stubEnv("FILE_RECORDS_TABLE", "petroglyph-file-records-test");
     vi.stubEnv("MICROSOFT_CLIENT_ID", "test-client-id");
+    vi.stubEnv("MICROSOFT_CLIENT_SECRET", "test-client-secret");
     mockDbSend.mockReset();
     mockSsmSend.mockReset();
     mockFetch.mockReset();


### PR DESCRIPTION
## Problem
Lifecycle reauthorization still failed after reconnect.

CloudWatch showed refresh failures, and investigation found two issues:
- Lifecycle was refreshing with the global SSM refresh token, but reconnect updates the per-user token in REFRESH_TOKENS_TABLE.
- Refresh requests did not include client_secret, which is required for this confidential app registration.

## Fix
- onedrive-lifecycle: read refresh token by clientState (user id) from REFRESH_TOKENS_TABLE and use that for reauthorizationRequired.
- onedrive-middleware: include MICROSOFT_CLIENT_SECRET in refresh token requests.
- Update affected tests in lifecycle, middleware, and sync-run suites.

## Validation
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test