### PR TITLE
fix(api): keep OneDrive user token state in DynamoDB

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -215,7 +215,7 @@ sequenceDiagram
     Note over CloudAPI: validate & delete state token<br/>(retrieve PKCE verifier from DynamoDB)
     CloudAPI->>Microsoft: token exchange (code + verifier)
     Microsoft-->>CloudAPI: access token + refresh token
-    Note over CloudAPI: store 3 tokens in SSM (SecureString)<br/>register Graph subscription (non-blocking)<br/>upsert SyncProfile in DynamoDB
+    Note over CloudAPI: store OneDrive tokens in DynamoDB<br/>register Graph subscription (non-blocking)<br/>upsert SyncProfile in DynamoDB
     CloudAPI-->>Plugin: { status: 'connected' }
 ```
 
@@ -228,26 +228,26 @@ sequenceDiagram
 7. Plugin sends `{ code, state }` to `POST /onedrive/connect` on the cloud API (JWT-protected, so the user must be authenticated).
 8. Cloud API validates the state token against DynamoDB (`type='onedrive_state'`, TTL check) → 401 if invalid or expired. The state record is deleted immediately after lookup (one-time-use), and the PKCE `verifier` is read from it.
 9. Cloud API completes the PKCE token exchange with Microsoft using the code, retrieved verifier, and client secret (loaded from SSM), receiving an **access token** (TTL ~1 hour) and a **refresh token** (TTL up to 90 days with `offline_access`). Returns 502 if the exchange fails.
-10. `access_token`, `refresh_token`, and `token-expiry` (ISO 8601) are each stored as **SSM SecureString** parameters (with `Overwrite=true`).
+10. `access_token`, `refresh_token`, and `expirySeconds` are stored on the user's `refresh_tokens` DynamoDB record (`tokenHash=userId`).
 11. Cloud API attempts to register a **Microsoft Graph change notification subscription** for the user's OneDrive. The requested `expirationDateTime` is capped to Graph's maximum allowed window so registration does not fail due to an out-of-range expiry. Failure is still non-blocking — a warning is logged and the request continues.
 12. Cloud API upserts a **SyncProfile** in DynamoDB (`PK=userId`, `SK='default'`, `oneDriveConnected=true`).
 13. Returns `{ status: 'connected' }` to the plugin.
 
 ### Token Lifecycle
 
-Access tokens expire approximately every hour. The service uses **lazy refresh**: a Hono middleware (`onedriveMiddleware`) mounted on all `/onedrive/*` routes in the API Handler Lambda reads the access token and its expiry from SSM on every request. If the token is within **10 minutes** of expiry (or already expired) it proactively exchanges the refresh token with Microsoft and writes the new access token, refresh token, and expiry back to SSM before the downstream handler runs.
+Access tokens expire approximately every hour. The service uses **lazy refresh**: a Hono middleware (`onedriveMiddleware`) mounted on all `/onedrive/*` routes in the API Handler Lambda reads the access token and its expiry from the user's DynamoDB `refresh_tokens` record on every request. If the token is within **10 minutes** of expiry (or already expired) it proactively exchanges the refresh token with Microsoft and writes the new access token, refresh token, and expiry back to DynamoDB before the downstream handler runs.
 
 The refreshed (or current) access token is injected into the Hono context as `onedriveAccessToken` for downstream `/onedrive/*` handlers to use.
 
 ```mermaid
 flowchart TD
-    A[/onedrive/* request] --> B[Read access-token + refresh-token + token-expiry from SSM]
-    B -- SSM error --> Z[Inject undefined token\ncontinue to handler]
+    A[/onedrive/* request] --> B[Read access-token + refresh-token + token-expiry from DynamoDB]
+    B -- read error --> Z[Inject undefined token\ncontinue to handler]
     B --> C{Expiry within 10 min?}
     C -- No --> G[Inject current access token\ncontinue to handler]
     C -- Yes / already expired --> D[POST to Microsoft token endpoint]
     D --> E{Refresh succeeded?}
-    E -- Yes --> F[Write new tokens to SSM\nInject new access token\ncontinue to handler]
+    E -- Yes --> F[Write new tokens to DynamoDB\nInject new access token\ncontinue to handler]
     E -- No: error --> W[Log error\nInject stale access token\ncontinue to handler]
 ```
 
@@ -264,11 +264,11 @@ Microsoft Graph change notification subscriptions expire every 3 days (maximum).
 
 Microsoft sends lifecycle events to a dedicated `lifecycleNotificationUrl`, handled by the **Lifecycle Notification Lambda** (separate from the webhook receiver):
 
-| Lifecycle event           | Action                                                                                                                                                                                                         |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `reauthorizationRequired` | Lambda attempts token refresh + subscription renewal automatically using the current OneDrive token. If renewal succeeds, no user action is needed. If it fails, marks OneDrive as `disconnected` in DynamoDB. |
-| `subscriptionRemoved`     | Marks OneDrive as `disconnected` in DynamoDB immediately.                                                                                                                                                      |
-| `missed`                  | Logs to CloudWatch; Processor Lambda will catch up on next manual sync.                                                                                                                                        |
+| Lifecycle event           | Action                                                                                                                                                                                                             |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `reauthorizationRequired` | Lambda reads the user's refresh token from DynamoDB, performs token refresh, stores rotated tokens back to DynamoDB, then renews the subscription. If renewal fails, marks OneDrive as `disconnected` in DynamoDB. |
+| `subscriptionRemoved`     | Marks OneDrive as `disconnected` in DynamoDB immediately.                                                                                                                                                          |
+| `missed`                  | Logs to CloudWatch; Processor Lambda will catch up on next manual sync.                                                                                                                                            |
 
 In all `disconnected` cases the plugin surfaces a **"Reconnect OneDrive"** prompt on its next `/status` poll, explaining the reason. There is no SNS email alert — the plugin is the primary UI for error surfacing.
 
@@ -374,15 +374,12 @@ All parameters use the prefix `/petroglyph/`.
 | `/petroglyph/jwt/public-key`                | String       | RS256 public key (PEM) for verifying JWTs                                     |
 | `/petroglyph/microsoft/entra/client-id`     | String       | Entra ID app client ID                                                        |
 | `/petroglyph/microsoft/entra/client-secret` | SecureString | Entra ID app client secret                                                    |
-| `/petroglyph/onedrive/access-token`         | SecureString | Current OneDrive access token                                                 |
-| `/petroglyph/onedrive/refresh-token`        | SecureString | Current OneDrive refresh token                                                |
-| `/petroglyph/onedrive/token-expiry`         | SecureString | ISO 8601 expiry of the access token                                           |
 | `/petroglyph/onedrive/subscription-id`      | String       | Microsoft Graph subscription ID                                               |
 | `/petroglyph/config/target-branch`          | String       | Git branch to commit to (e.g. `main`)                                         |
 | `/petroglyph/config/initial-sync`           | String       | `true` \| `false` — return all existing files when plugin has no change token |
 | `/petroglyph/config/retention-days`         | String       | Days to retain S3 objects after staging (default: `90`)                       |
 
-> **Note:** In Phase 3 (multi-user), per-user OneDrive tokens and settings will move to DynamoDB. SSM is appropriate for a single-user personal deployment.
+> **Note:** Per-user OneDrive token state is stored in DynamoDB (`refresh_tokens` table). SSM stores only system-level configuration/secrets.
 
 ---
 

--- a/packages/api/src/onedrive-lifecycle.test.ts
+++ b/packages/api/src/onedrive-lifecycle.test.ts
@@ -1,17 +1,11 @@
-import { PutParameterCommand } from "@aws-sdk/client-ssm";
 import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockDbSend = vi.hoisted(() => vi.fn());
-const mockSsmSend = vi.hoisted(() => vi.fn());
 const mockFetch = vi.hoisted(() => vi.fn());
 
 vi.mock("./db.js", () => ({
   docClient: { send: mockDbSend },
-}));
-
-vi.mock("./ssm.js", () => ({
-  ssmClient: { send: mockSsmSend },
 }));
 
 vi.stubGlobal("fetch", mockFetch);
@@ -22,7 +16,6 @@ describe("POST /onedrive/lifecycle", () => {
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     mockDbSend.mockReset();
-    mockSsmSend.mockReset();
     mockFetch.mockReset();
     vi.stubEnv("USERS_TABLE", "petroglyph-users-test");
     vi.stubEnv("REFRESH_TOKENS_TABLE", "petroglyph-refresh_tokens-test");
@@ -47,23 +40,10 @@ describe("POST /onedrive/lifecycle", () => {
     });
   }
 
-  function setupSsmMock(entries: CommandResponseEntry[]): void {
-    mockSsmSend.mockImplementation((command: unknown) => {
-      const match = entries.find((entry) => command instanceof entry.command);
-      return Promise.resolve(match?.response ?? {});
-    });
-  }
-
   function updateCalls(): Array<[unknown]> {
     return mockDbSend.mock.calls.filter(([command]) => command instanceof UpdateCommand) as Array<
       [unknown]
     >;
-  }
-
-  function putParameterCalls(): Array<[unknown]> {
-    return mockSsmSend.mock.calls.filter(
-      ([command]) => command instanceof PutParameterCommand,
-    ) as Array<[unknown]>;
   }
 
   it("returns the Microsoft validation token as plain text", async () => {
@@ -120,7 +100,6 @@ describe("POST /onedrive/lifecycle", () => {
     setupDbMock([
       { command: GetCommand, response: { Item: { refreshToken: "existing-refresh-token" } } },
     ]);
-    setupSsmMock([{ command: PutParameterCommand, response: {} }]);
     mockFetch.mockImplementation((url: string) => {
       if (url === "https://login.microsoftonline.com/common/oauth2/v2.0/token") {
         return Promise.resolve({
@@ -185,43 +164,44 @@ describe("POST /onedrive/lifecycle", () => {
     );
 
     await vi.waitFor(() => {
-      expect(updateCalls()).toHaveLength(1);
-      expect(
-        putParameterCalls().some(
-          ([command]) =>
-            (command as { input: { Name: string } }).input.Name ===
-            "/petroglyph/onedrive/subscription-expiry",
-        ),
-      ).toBe(true);
+      expect(updateCalls()).toHaveLength(2);
     });
 
-    const parameterNames = putParameterCalls().map(
-      ([command]) => (command as { input: { Name: string } }).input.Name,
+    const updateCommands = updateCalls().map(([command]) => command as { input: unknown });
+    const tokenUpdate = updateCommands.find(
+      (command) =>
+        (command.input as { TableName?: string }).TableName === "petroglyph-refresh_tokens-test",
     );
-    expect(parameterNames).toContain("/petroglyph/onedrive/subscription-expiry");
+    expect(tokenUpdate).toBeDefined();
+    expect((tokenUpdate?.input as { Key: { tokenHash: string } }).Key).toEqual({
+      tokenHash: "user-123",
+    });
+    expect(
+      (tokenUpdate?.input as { ExpressionAttributeValues: { [key: string]: unknown } })
+        .ExpressionAttributeValues[":accessToken"],
+    ).toBe("new-access-token");
+    expect(
+      (tokenUpdate?.input as { ExpressionAttributeValues: { [key: string]: unknown } })
+        .ExpressionAttributeValues[":refreshToken"],
+    ).toBe("new-refresh-token");
 
-    const updateCall = updateCalls()[0];
-    if (!updateCall) {
-      throw new Error("Expected one UpdateCommand call");
-    }
-
-    const [updateCommand] = updateCall as [
-      {
-        input: {
-          Key: { userId: string };
-          ExpressionAttributeValues: { [key: string]: unknown };
-        };
-      },
-    ];
-    expect(updateCommand.input.Key).toEqual({ userId: "user-123" });
-    expect(updateCommand.input.ExpressionAttributeValues[":status"]).toBe("connected");
+    const statusUpdate = updateCommands.find(
+      (command) => (command.input as { TableName?: string }).TableName === "petroglyph-users-test",
+    );
+    expect(statusUpdate).toBeDefined();
+    expect((statusUpdate?.input as { Key: { userId: string } }).Key).toEqual({
+      userId: "user-123",
+    });
+    expect(
+      (statusUpdate?.input as { ExpressionAttributeValues: { [key: string]: unknown } })
+        .ExpressionAttributeValues[":status"],
+    ).toBe("connected");
   });
 
   it("marks the user as reconnect_required when token refresh fails", async () => {
     setupDbMock([
       { command: GetCommand, response: { Item: { refreshToken: "existing-refresh-token" } } },
     ]);
-    setupSsmMock([{ command: PutParameterCommand, response: {} }]);
     mockFetch.mockResolvedValue({
       ok: false,
       status: 401,
@@ -270,13 +250,28 @@ describe("POST /onedrive/lifecycle", () => {
     setupDbMock([
       { command: GetCommand, response: { Item: { refreshToken: "existing-refresh-token" } } },
     ]);
-    setupSsmMock([{ command: PutParameterCommand, response: {} }]);
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error",
-      json: () => Promise.resolve({}),
-    } as Response);
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "https://login.microsoftonline.com/common/oauth2/v2.0/token") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              access_token: "new-access-token",
+              refresh_token: "new-refresh-token",
+              expires_in: 3600,
+            }),
+        } as Response);
+      }
+      if (url === "https://graph.microsoft.com/v1.0/subscriptions/sub-456") {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          json: () => Promise.resolve({}),
+        } as Response);
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
 
     const response = await app.request("/onedrive/lifecycle", {
       method: "POST",
@@ -295,24 +290,23 @@ describe("POST /onedrive/lifecycle", () => {
     expect(response.status).toBe(202);
 
     await vi.waitFor(() => {
-      expect(updateCalls()).toHaveLength(1);
+      expect(updateCalls()).toHaveLength(2);
     });
 
-    const updateCall = updateCalls()[0];
-    if (!updateCall) {
-      throw new Error("Expected one UpdateCommand call");
-    }
-
-    const [updateCommand] = updateCall as [
-      {
-        input: {
-          Key: { userId: string };
-          ExpressionAttributeValues: { [key: string]: unknown };
-        };
-      },
-    ];
-    expect(updateCommand.input.Key).toEqual({ userId: "user-456" });
-    expect(updateCommand.input.ExpressionAttributeValues[":status"]).toBe("reconnect_required");
+    const statusUpdate = updateCalls()
+      .map(([command]) => command as { input: unknown })
+      .find(
+        (command) =>
+          (command.input as { TableName?: string }).TableName === "petroglyph-users-test",
+      );
+    expect(statusUpdate).toBeDefined();
+    expect((statusUpdate?.input as { Key: { userId: string } }).Key).toEqual({
+      userId: "user-456",
+    });
+    expect(
+      (statusUpdate?.input as { ExpressionAttributeValues: { [key: string]: unknown } })
+        .ExpressionAttributeValues[":status"],
+    ).toBe("reconnect_required");
   });
 
   it("returns 202 after subscriptionRemoved work finishes", async () => {
@@ -339,7 +333,6 @@ describe("POST /onedrive/lifecycle", () => {
     setupDbMock([
       { command: GetCommand, response: { Item: { refreshToken: "existing-refresh-token" } } },
     ]);
-    setupSsmMock([{ command: PutParameterCommand, response: {} }]);
     mockFetch.mockImplementation((url: string) => {
       if (url === "https://login.microsoftonline.com/common/oauth2/v2.0/token") {
         return Promise.resolve({
@@ -380,14 +373,7 @@ describe("POST /onedrive/lifecycle", () => {
     });
 
     expect(response.status).toBe(202);
-    expect(updateCalls()).toHaveLength(1);
-    expect(
-      putParameterCalls().some(
-        ([command]) =>
-          (command as { input: { Name: string } }).input.Name ===
-          "/petroglyph/onedrive/subscription-expiry",
-      ),
-    ).toBe(true);
+    expect(updateCalls()).toHaveLength(2);
   });
 
   it("returns 202 after lifecycle processing succeeds", async () => {

--- a/packages/api/src/onedrive-lifecycle.ts
+++ b/packages/api/src/onedrive-lifecycle.ts
@@ -1,9 +1,6 @@
-import { PutParameterCommand } from "@aws-sdk/client-ssm";
 import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { Context } from "hono";
 import { docClient } from "./db.js";
-import { refreshOneDriveToken } from "./onedrive-middleware.js";
-import { ssmClient } from "./ssm.js";
 
 function usersTable(): string {
   return process.env["USERS_TABLE"] ?? "petroglyph-users-default";
@@ -87,7 +84,11 @@ interface GraphSubscriptionResponse {
   expirationDateTime: string;
 }
 
-const SSM_SUBSCRIPTION_EXPIRY = "/petroglyph/onedrive/subscription-expiry";
+interface MicrosoftTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+}
 
 function parseGraphSubscriptionResponse(value: unknown): GraphSubscriptionResponse {
   if (!isRecord(value) || typeof value["expirationDateTime"] !== "string") {
@@ -119,13 +120,71 @@ async function renewGraphSubscription(
   return data.expirationDateTime;
 }
 
-async function storeSubscriptionExpiry(expirationDateTime: string): Promise<void> {
-  await ssmClient.send(
-    new PutParameterCommand({
-      Name: SSM_SUBSCRIPTION_EXPIRY,
-      Value: expirationDateTime,
-      Type: "SecureString",
-      Overwrite: true,
+function parseMicrosoftTokenResponse(value: unknown): MicrosoftTokenResponse {
+  if (!isRecord(value)) {
+    throw new Error("Microsoft token response is not an object");
+  }
+  if (typeof value["access_token"] !== "string") {
+    throw new Error("Microsoft token response missing string access_token");
+  }
+  if (typeof value["refresh_token"] !== "string") {
+    throw new Error("Microsoft token response missing string refresh_token");
+  }
+  if (typeof value["expires_in"] !== "number") {
+    throw new Error("Microsoft token response missing number expires_in");
+  }
+  return {
+    access_token: value["access_token"],
+    refresh_token: value["refresh_token"],
+    expires_in: value["expires_in"],
+  };
+}
+
+async function refreshUserToken(refreshToken: string): Promise<MicrosoftTokenResponse> {
+  const clientId = process.env["MICROSOFT_CLIENT_ID"];
+  if (!clientId) throw new Error("MICROSOFT_CLIENT_ID env var not set");
+  const clientSecret = process.env["MICROSOFT_CLIENT_SECRET"];
+  if (!clientSecret) throw new Error("MICROSOFT_CLIENT_SECRET env var not set");
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    scope: "files.read offline_access",
+  });
+
+  const response = await fetch("https://login.microsoftonline.com/common/oauth2/v2.0/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!response.ok) {
+    throw new Error(`Microsoft token refresh failed with status ${response.status}`);
+  }
+
+  return parseMicrosoftTokenResponse(await response.json());
+}
+
+async function storeUserTokens(
+  userId: string,
+  accessToken: string,
+  refreshToken: string,
+  expiresIn: number,
+): Promise<void> {
+  const expirySeconds = Math.floor(Date.now() / 1000) + expiresIn;
+  await docClient.send(
+    new UpdateCommand({
+      TableName: refreshTokensTable(),
+      Key: { tokenHash: userId },
+      UpdateExpression:
+        "SET accessToken = :accessToken, refreshToken = :refreshToken, expirySeconds = :expirySeconds, updatedAt = :updatedAt",
+      ExpressionAttributeValues: {
+        ":accessToken": accessToken,
+        ":refreshToken": refreshToken,
+        ":expirySeconds": expirySeconds,
+        ":updatedAt": new Date().toISOString(),
+      },
     }),
   );
 }
@@ -145,10 +204,14 @@ async function handleReauthorizationRequired(notification: LifecycleNotification
     refreshTokenResult.Item as unknown,
     notification.clientState,
   );
-
-  const accessToken = await refreshOneDriveToken(refreshToken);
-  const subscriptionExpiry = await renewGraphSubscription(notification.subscriptionId, accessToken);
-  await storeSubscriptionExpiry(subscriptionExpiry);
+  const refreshed = await refreshUserToken(refreshToken);
+  await storeUserTokens(
+    notification.clientState,
+    refreshed.access_token,
+    refreshed.refresh_token,
+    refreshed.expires_in,
+  );
+  await renewGraphSubscription(notification.subscriptionId, refreshed.access_token);
   await markConnected(notification.clientState);
 }
 

--- a/packages/api/src/onedrive-middleware.test.ts
+++ b/packages/api/src/onedrive-middleware.test.ts
@@ -1,14 +1,14 @@
-import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppVariables } from "./auth-middleware.js";
 
-const mockSsmSend = vi.hoisted(() => vi.fn());
+const mockDbSend = vi.hoisted(() => vi.fn());
 const mockFetch = vi.hoisted(() => vi.fn());
 
-vi.mock("./ssm.js", () => ({
-  ssmClient: { send: mockSsmSend },
+vi.mock("./db.js", () => ({
+  docClient: { send: mockDbSend },
 }));
 
 import { onedriveMiddleware } from "./onedrive-middleware.js";
@@ -20,31 +20,21 @@ const REFRESH_TOKEN = "existing-refresh-token";
 const NEW_ACCESS_TOKEN = "new-access-token";
 const NEW_REFRESH_TOKEN = "new-refresh-token";
 
-const SSM_ACCESS_TOKEN = "/petroglyph/onedrive/access-token";
-const SSM_TOKEN_EXPIRY = "/petroglyph/onedrive/token-expiry";
-const SSM_REFRESH_TOKEN = "/petroglyph/onedrive/refresh-token";
-
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function expiryInFuture(offsetMs: number): string {
-  return new Date(Date.now() + offsetMs).toISOString();
-}
-
-function setupSsmMock(tokenExpiry: string): void {
-  mockSsmSend.mockImplementation((cmd: unknown) => {
-    if (cmd instanceof GetParameterCommand) {
-      const name = (cmd as { input: { Name: string } }).input.Name;
-      if (name === SSM_ACCESS_TOKEN) {
-        return Promise.resolve({ Parameter: { Value: ACCESS_TOKEN } });
-      }
-      if (name === SSM_TOKEN_EXPIRY) {
-        return Promise.resolve({ Parameter: { Value: tokenExpiry } });
-      }
-      if (name === SSM_REFRESH_TOKEN) {
-        return Promise.resolve({ Parameter: { Value: REFRESH_TOKEN } });
-      }
+function setupDbMock(tokenExpirySecondsOffset: number): void {
+  const expirySeconds = Math.floor((Date.now() + tokenExpirySecondsOffset) / 1000);
+  mockDbSend.mockImplementation((cmd: unknown) => {
+    if (cmd instanceof GetCommand) {
+      return Promise.resolve({
+        Item: {
+          accessToken: ACCESS_TOKEN,
+          refreshToken: REFRESH_TOKEN,
+          expirySeconds,
+        },
+      });
     }
-    if (cmd instanceof PutParameterCommand) {
+    if (cmd instanceof UpdateCommand) {
       return Promise.resolve({});
     }
     return Promise.resolve({});
@@ -73,10 +63,12 @@ function setupFetchMock(
 
 function makeTestApp(): Hono<{ Variables: AppVariables }> {
   const app = new Hono<{ Variables: AppVariables }>();
-  app.use("*", (c, next) =>
+  app.use("*", async (c, next) => {
+    c.set("userId", "user-42");
+    c.set("username", "octocat");
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    onedriveMiddleware(c as unknown as Context<{ Variables: AppVariables }>, next),
-  );
+    await onedriveMiddleware(c as unknown as Context<{ Variables: AppVariables }>, next);
+  });
   app.get("/test", (c) => c.json({ token: c.get("onedriveAccessToken") ?? null }));
   return app;
 }
@@ -95,14 +87,13 @@ describe("onedriveMiddleware", () => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
-    mockSsmSend.mockReset();
+    mockDbSend.mockReset();
     mockFetch.mockReset();
   });
 
   describe("token not near expiry", () => {
     it("passes through without refreshing and sets access token in context", async () => {
-      const expiry = expiryInFuture(30 * 60 * 1000); // 30 min away
-      setupSsmMock(expiry);
+      setupDbMock(30 * 60 * 1000); // 30 min away
 
       const app = makeTestApp();
       const res = await app.request("/test");
@@ -116,8 +107,7 @@ describe("onedriveMiddleware", () => {
 
   describe("token within 10 minutes of expiry", () => {
     it("refreshes the token and sets new access token in context", async () => {
-      const expiry = expiryInFuture(5 * 60 * 1000); // 5 min away
-      setupSsmMock(expiry);
+      setupDbMock(5 * 60 * 1000); // 5 min away
       setupFetchMock();
 
       const app = makeTestApp();
@@ -129,8 +119,7 @@ describe("onedriveMiddleware", () => {
     });
 
     it("POSTs to Microsoft token endpoint with correct params", async () => {
-      const expiry = expiryInFuture(5 * 60 * 1000);
-      setupSsmMock(expiry);
+      setupDbMock(5 * 60 * 1000);
       setupFetchMock();
 
       const app = makeTestApp();
@@ -152,41 +141,33 @@ describe("onedriveMiddleware", () => {
       expect(params.get("scope")).toBe("files.read offline_access");
     });
 
-    it("writes new tokens back to SSM with Overwrite=true", async () => {
-      const expiry = expiryInFuture(5 * 60 * 1000);
-      setupSsmMock(expiry);
+    it("writes new tokens back to DynamoDB", async () => {
+      setupDbMock(5 * 60 * 1000);
       setupFetchMock();
 
       const app = makeTestApp();
       await app.request("/test");
 
-      const putCalls = mockSsmSend.mock.calls.filter(([cmd]) => cmd instanceof PutParameterCommand);
-      expect(putCalls).toHaveLength(3);
-
-      const putInputs = putCalls.map(
-        ([cmd]) => (cmd as { input: { Name: string; Value: string; Overwrite: boolean } }).input,
-      );
-
-      const accessTokenPut = putInputs.find((i) => i.Name === SSM_ACCESS_TOKEN);
-      expect(accessTokenPut?.Value).toBe(NEW_ACCESS_TOKEN);
-      expect(accessTokenPut?.Overwrite).toBe(true);
-
-      const refreshTokenPut = putInputs.find((i) => i.Name === SSM_REFRESH_TOKEN);
-      expect(refreshTokenPut?.Value).toBe(NEW_REFRESH_TOKEN);
-      expect(refreshTokenPut?.Overwrite).toBe(true);
-
-      const expiryPut = putInputs.find((i) => i.Name === SSM_TOKEN_EXPIRY);
-      expect(expiryPut?.Overwrite).toBe(true);
-      expect(typeof expiryPut?.Value).toBe("string");
-      if (expiryPut === undefined) throw new Error("expiryPut should be defined");
-      expect(() => new Date(expiryPut.Value)).not.toThrow();
+      const updateCalls = mockDbSend.mock.calls.filter(([cmd]) => cmd instanceof UpdateCommand);
+      expect(updateCalls).toHaveLength(1);
+      const updateInput = (
+        updateCalls[0] as [
+          {
+            input: {
+              ExpressionAttributeValues: { [key: string]: unknown };
+            };
+          },
+        ]
+      )[0].input;
+      expect(updateInput.ExpressionAttributeValues[":accessToken"]).toBe(NEW_ACCESS_TOKEN);
+      expect(updateInput.ExpressionAttributeValues[":refreshToken"]).toBe(NEW_REFRESH_TOKEN);
+      expect(typeof updateInput.ExpressionAttributeValues[":expirySeconds"]).toBe("number");
     });
   });
 
   describe("token already expired", () => {
     it("refreshes when token is already past its expiry", async () => {
-      const expiry = expiryInFuture(-60 * 1000); // 1 min ago
-      setupSsmMock(expiry);
+      setupDbMock(-60 * 1000); // 1 min ago
       setupFetchMock();
 
       const app = makeTestApp();
@@ -199,9 +180,9 @@ describe("onedriveMiddleware", () => {
     });
   });
 
-  describe("SSM read error", () => {
-    it("passes through with undefined token when SSM read fails", async () => {
-      mockSsmSend.mockRejectedValue(new Error("SSM unavailable"));
+  describe("DynamoDB read error", () => {
+    it("passes through with undefined token when DynamoDB read fails", async () => {
+      mockDbSend.mockRejectedValue(new Error("DynamoDB unavailable"));
 
       const app = makeTestApp();
       const res = await app.request("/test");
@@ -214,8 +195,7 @@ describe("onedriveMiddleware", () => {
 
   describe("Microsoft refresh API error", () => {
     it("passes through with old access token when Microsoft returns non-ok response", async () => {
-      const expiry = expiryInFuture(5 * 60 * 1000);
-      setupSsmMock(expiry);
+      setupDbMock(5 * 60 * 1000);
       setupFetchMock({ ok: false, status: 500 });
 
       const app = makeTestApp();
@@ -227,8 +207,7 @@ describe("onedriveMiddleware", () => {
     });
 
     it("passes through with old access token when fetch throws", async () => {
-      const expiry = expiryInFuture(5 * 60 * 1000);
-      setupSsmMock(expiry);
+      setupDbMock(5 * 60 * 1000);
       mockFetch.mockRejectedValue(new Error("network error"));
 
       const app = makeTestApp();
@@ -242,8 +221,7 @@ describe("onedriveMiddleware", () => {
 
   describe("Microsoft token response validation", () => {
     it("passes through with old token when response is missing access_token", async () => {
-      const expiry = expiryInFuture(5 * 60 * 1000);
-      setupSsmMock(expiry);
+      setupDbMock(5 * 60 * 1000);
       setupFetchMock({
         body: { refresh_token: NEW_REFRESH_TOKEN, expires_in: 3600 },
       });
@@ -257,8 +235,7 @@ describe("onedriveMiddleware", () => {
     });
 
     it("passes through with old token when response is missing refresh_token", async () => {
-      const expiry = expiryInFuture(5 * 60 * 1000);
-      setupSsmMock(expiry);
+      setupDbMock(5 * 60 * 1000);
       setupFetchMock({
         body: { access_token: NEW_ACCESS_TOKEN, expires_in: 3600 },
       });
@@ -272,8 +249,7 @@ describe("onedriveMiddleware", () => {
     });
 
     it("passes through with old token when expires_in is not a number", async () => {
-      const expiry = expiryInFuture(5 * 60 * 1000);
-      setupSsmMock(expiry);
+      setupDbMock(5 * 60 * 1000);
       setupFetchMock({
         body: {
           access_token: NEW_ACCESS_TOKEN,
@@ -291,8 +267,7 @@ describe("onedriveMiddleware", () => {
     });
 
     it("passes through with old token when response is not an object", async () => {
-      const expiry = expiryInFuture(5 * 60 * 1000);
-      setupSsmMock(expiry);
+      setupDbMock(5 * 60 * 1000);
       setupFetchMock({ body: "unexpected string" });
 
       const app = makeTestApp();

--- a/packages/api/src/onedrive-middleware.ts
+++ b/packages/api/src/onedrive-middleware.ts
@@ -1,36 +1,51 @@
-import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { MiddlewareHandler } from "hono";
 import type { AppVariables } from "./auth-middleware.js";
-import { ssmClient } from "./ssm.js";
+import { docClient } from "./db.js";
 
 export const TEN_MINUTES_MS = 10 * 60 * 1000;
 
-const SSM_ACCESS_TOKEN = "/petroglyph/onedrive/access-token";
-const SSM_TOKEN_EXPIRY = "/petroglyph/onedrive/token-expiry";
-const SSM_REFRESH_TOKEN = "/petroglyph/onedrive/refresh-token";
-
-async function readSsmString(name: string): Promise<string> {
-  const result = await ssmClient.send(
-    new GetParameterCommand({ Name: name, WithDecryption: true }),
-  );
-  const value = result.Parameter?.Value;
-  if (!value) throw new Error(`SSM parameter not found or empty: ${name}`);
-  return value;
+function refreshTokensTable(): string {
+  return process.env["REFRESH_TOKENS_TABLE"] ?? "petroglyph-refresh_tokens-default";
 }
 
 export interface OneDriveParams {
   accessToken: string;
-  tokenExpiry: string;
+  tokenExpirySeconds: number;
   refreshToken: string;
 }
 
-export async function readOneDriveParams(): Promise<OneDriveParams> {
-  const [accessToken, tokenExpiry, refreshToken] = await Promise.all([
-    readSsmString(SSM_ACCESS_TOKEN),
-    readSsmString(SSM_TOKEN_EXPIRY),
-    readSsmString(SSM_REFRESH_TOKEN),
-  ]);
-  return { accessToken, tokenExpiry, refreshToken };
+function parseOneDriveParams(value: unknown, userId: string): OneDriveParams {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`OneDrive token record missing for user ${userId}`);
+  }
+  const item = value as { [key: string]: unknown };
+  if (typeof item["accessToken"] !== "string" || item["accessToken"].length === 0) {
+    throw new Error(`OneDrive accessToken missing for user ${userId}`);
+  }
+  if (typeof item["refreshToken"] !== "string" || item["refreshToken"].length === 0) {
+    throw new Error(`OneDrive refreshToken missing for user ${userId}`);
+  }
+  if (typeof item["expirySeconds"] !== "number") {
+    throw new Error(`OneDrive expirySeconds missing for user ${userId}`);
+  }
+
+  return {
+    accessToken: item["accessToken"],
+    refreshToken: item["refreshToken"],
+    tokenExpirySeconds: item["expirySeconds"],
+  };
+}
+
+export async function readOneDriveParams(userId: string): Promise<OneDriveParams> {
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: refreshTokensTable(),
+      Key: { tokenHash: userId },
+    }),
+  );
+
+  return parseOneDriveParams(result.Item, userId);
 }
 
 interface MicrosoftTokenResponse {
@@ -55,7 +70,9 @@ function assertMicrosoftTokenResponse(value: unknown): asserts value is Microsof
   }
 }
 
-export async function refreshOneDriveToken(currentRefreshToken: string): Promise<string> {
+export async function refreshOneDriveToken(
+  currentRefreshToken: string,
+): Promise<MicrosoftTokenResponse> {
   const clientId = process.env["MICROSOFT_CLIENT_ID"];
   if (!clientId) throw new Error("MICROSOFT_CLIENT_ID env var not set");
   const clientSecret = process.env["MICROSOFT_CLIENT_SECRET"];
@@ -82,43 +99,46 @@ export async function refreshOneDriveToken(currentRefreshToken: string): Promise
   const data: unknown = await response.json();
   assertMicrosoftTokenResponse(data);
 
-  const { access_token, refresh_token, expires_in } = data;
-  const newExpiry = new Date(Date.now() + expires_in * 1000).toISOString();
-
-  await Promise.all([
-    ssmClient.send(
-      new PutParameterCommand({
-        Name: SSM_ACCESS_TOKEN,
-        Value: access_token,
-        Overwrite: true,
-      }),
-    ),
-    ssmClient.send(
-      new PutParameterCommand({
-        Name: SSM_TOKEN_EXPIRY,
-        Value: newExpiry,
-        Overwrite: true,
-      }),
-    ),
-    ssmClient.send(
-      new PutParameterCommand({
-        Name: SSM_REFRESH_TOKEN,
-        Value: refresh_token,
-        Overwrite: true,
-      }),
-    ),
-  ]);
-
-  return access_token;
+  return data;
 }
 
-export async function resolveOneDriveAccessToken(): Promise<string> {
-  const params = await readOneDriveParams();
-  const msUntilExpiry = new Date(params.tokenExpiry).getTime() - Date.now();
+async function storeOneDriveParams(
+  userId: string,
+  accessToken: string,
+  refreshToken: string,
+  expiresIn: number,
+): Promise<void> {
+  const expirySeconds = Math.floor(Date.now() / 1000) + expiresIn;
+  await docClient.send(
+    new UpdateCommand({
+      TableName: refreshTokensTable(),
+      Key: { tokenHash: userId },
+      UpdateExpression:
+        "SET accessToken = :accessToken, refreshToken = :refreshToken, expirySeconds = :expirySeconds, updatedAt = :updatedAt",
+      ExpressionAttributeValues: {
+        ":accessToken": accessToken,
+        ":refreshToken": refreshToken,
+        ":expirySeconds": expirySeconds,
+        ":updatedAt": new Date().toISOString(),
+      },
+    }),
+  );
+}
+
+export async function resolveOneDriveAccessToken(userId: string): Promise<string> {
+  const params = await readOneDriveParams(userId);
+  const msUntilExpiry = params.tokenExpirySeconds * 1000 - Date.now();
 
   if (msUntilExpiry <= TEN_MINUTES_MS) {
     try {
-      return await refreshOneDriveToken(params.refreshToken);
+      const refreshed = await refreshOneDriveToken(params.refreshToken);
+      await storeOneDriveParams(
+        userId,
+        refreshed.access_token,
+        refreshed.refresh_token,
+        refreshed.expires_in,
+      );
+      return refreshed.access_token;
     } catch (err) {
       console.error("[onedrive-middleware] token refresh failed:", err);
     }
@@ -131,11 +151,16 @@ export const onedriveMiddleware: MiddlewareHandler<{
   Variables: AppVariables;
 }> = async (c, next) => {
   let accessToken: string | undefined;
+  const userId = c.get("userId");
 
-  try {
-    accessToken = await resolveOneDriveAccessToken();
-  } catch (err) {
-    console.error("[onedrive-middleware] SSM read failed:", err);
+  if (!userId) {
+    console.error("[onedrive-middleware] missing userId in request context");
+  } else {
+    try {
+      accessToken = await resolveOneDriveAccessToken(userId);
+    } catch (err) {
+      console.error("[onedrive-middleware] DynamoDB read failed:", err);
+    }
   }
 
   c.set("onedriveAccessToken", accessToken);

--- a/packages/api/src/sync-run.test.ts
+++ b/packages/api/src/sync-run.test.ts
@@ -1,5 +1,5 @@
 import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
-import { PutCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, PutCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { exportSPKI, generateKeyPair, SignJWT } from "jose";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -25,7 +25,6 @@ describe("POST /sync/run", () => {
   let publicKeyPem: string;
   const accessToken = "onedrive-access-token";
   const refreshToken = "onedrive-refresh-token";
-  const futureExpiry = new Date(Date.now() + 60 * 60 * 1000).toISOString();
 
   beforeAll(async () => {
     const keyPair = await generateKeyPair("RS256");
@@ -71,35 +70,9 @@ describe("POST /sync/run", () => {
     });
   }
 
-  function mockOneDriveSsm({
-    deltaToken,
-    tokenExpiry = futureExpiry,
-    onedriveRefreshToken = refreshToken,
-  }: {
-    deltaToken?: string;
-    tokenExpiry?: string;
-    onedriveRefreshToken?: string;
-  } = {}): void {
+  function mockDeltaTokenSsm({ deltaToken }: { deltaToken?: string } = {}): void {
     mockSsmSend.mockImplementation((command: unknown) => {
       if (command instanceof GetParameterCommand) {
-        if (command.input.Name === "/petroglyph/onedrive/access-token") {
-          return Promise.resolve({
-            Parameter: { Value: accessToken },
-          });
-        }
-
-        if (command.input.Name === "/petroglyph/onedrive/token-expiry") {
-          return Promise.resolve({
-            Parameter: { Value: tokenExpiry },
-          });
-        }
-
-        if (command.input.Name === "/petroglyph/onedrive/refresh-token") {
-          return Promise.resolve({
-            Parameter: { Value: onedriveRefreshToken },
-          });
-        }
-
         if (command.input.Name === "/petroglyph/onedrive/delta-token" && deltaToken !== undefined) {
           return Promise.resolve({
             Parameter: { Value: deltaToken },
@@ -119,9 +92,36 @@ describe("POST /sync/run", () => {
     });
   }
 
+  function mockOneDriveDb({
+    tokenExpiryOffsetMs = 60 * 60 * 1000,
+    onedriveAccessToken = accessToken,
+    onedriveRefreshToken = refreshToken,
+  }: {
+    tokenExpiryOffsetMs?: number;
+    onedriveAccessToken?: string;
+    onedriveRefreshToken?: string;
+  } = {}): void {
+    const expirySeconds = Math.floor((Date.now() + tokenExpiryOffsetMs) / 1000);
+    mockDbSend.mockImplementation((command: unknown) => {
+      if (command instanceof GetCommand) {
+        return Promise.resolve({
+          Item: {
+            accessToken: onedriveAccessToken,
+            refreshToken: onedriveRefreshToken,
+            expirySeconds,
+          },
+        });
+      }
+      if (command instanceof PutCommand || command instanceof UpdateCommand) {
+        return Promise.resolve({});
+      }
+      return Promise.resolve({});
+    });
+  }
+
   it("queues PDF items on a first run when no delta token exists", async () => {
-    mockOneDriveSsm();
-    mockDbSend.mockResolvedValue({});
+    mockDeltaTokenSsm();
+    mockOneDriveDb();
     mockFetch.mockResolvedValue({
       ok: true,
       json: () =>
@@ -195,8 +195,8 @@ describe("POST /sync/run", () => {
   });
 
   it("continues an incremental sync from the stored delta token across pages", async () => {
-    mockOneDriveSsm({ deltaToken: "delta-token-1" });
-    mockDbSend.mockResolvedValue({});
+    mockDeltaTokenSsm({ deltaToken: "delta-token-1" });
+    mockOneDriveDb();
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
@@ -282,8 +282,8 @@ describe("POST /sync/run", () => {
   });
 
   it("returns queued=0 when the delta query contains no new PDF items", async () => {
-    mockOneDriveSsm({ deltaToken: "delta-token-2" });
-    mockDbSend.mockResolvedValue({});
+    mockDeltaTokenSsm({ deltaToken: "delta-token-2" });
+    mockOneDriveDb();
     mockFetch.mockResolvedValue({
       ok: true,
       json: () =>
@@ -327,11 +327,11 @@ describe("POST /sync/run", () => {
   });
 
   it("refreshes an expiring access token before querying Graph", async () => {
-    mockOneDriveSsm({
-      tokenExpiry: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    mockDeltaTokenSsm();
+    mockOneDriveDb({
+      tokenExpiryOffsetMs: 5 * 60 * 1000,
       onedriveRefreshToken: "onedrive-refresh-token",
     });
-    mockDbSend.mockResolvedValue({});
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
@@ -375,8 +375,8 @@ describe("POST /sync/run", () => {
   });
 
   it("queues PDF files based on .pdf extension even without proper MIME type", async () => {
-    mockOneDriveSsm();
-    mockDbSend.mockResolvedValue({});
+    mockDeltaTokenSsm();
+    mockOneDriveDb();
     mockFetch.mockResolvedValue({
       ok: true,
       json: () =>
@@ -408,8 +408,8 @@ describe("POST /sync/run", () => {
   });
 
   it("returns 500 when Graph delta request fails with non-ok status", async () => {
-    mockOneDriveSsm();
-    mockDbSend.mockResolvedValue({});
+    mockDeltaTokenSsm();
+    mockOneDriveDb();
     mockFetch.mockResolvedValue({
       ok: false,
       status: 401,
@@ -421,8 +421,8 @@ describe("POST /sync/run", () => {
   });
 
   it("returns 500 when Graph response has invalid shape (missing value array)", async () => {
-    mockOneDriveSsm();
-    mockDbSend.mockResolvedValue({});
+    mockDeltaTokenSsm();
+    mockOneDriveDb();
     mockFetch.mockResolvedValue({
       ok: true,
       json: () =>

--- a/packages/api/src/sync-run.ts
+++ b/packages/api/src/sync-run.ts
@@ -160,7 +160,12 @@ async function storeDeltaToken(deltaToken: string): Promise<void> {
 }
 
 export async function handleSyncRun(c: Context): Promise<Response> {
-  const accessToken = await resolveOneDriveAccessToken();
+  const userIdValue: unknown = c.get("userId");
+  if (typeof userIdValue !== "string" || userIdValue.length === 0) {
+    throw new Error("Missing userId in sync run context");
+  }
+  const userId = userIdValue;
+  const accessToken = await resolveOneDriveAccessToken(userId);
   const startingDeltaToken = await readDeltaToken();
 
   let nextUrl: string | undefined = buildDeltaUrl(oneDriveFolder(), startingDeltaToken);


### PR DESCRIPTION
Summary:\n- Move OneDrive user token resolution and refresh in API middleware from SSM to DynamoDB (REFRESH_TOKENS_TABLE), keyed by userId\n- Keep lifecycle reauthorization fully DynamoDB-backed for user token read and write\n- Ensure refresh requests include client_secret and persist rotated tokens back to DynamoDB\n- Update sync-run to pass authenticated userId into token resolution\n- Update authentication docs to describe user-token state in DynamoDB and lifecycle behavior\n\nWhy:\nUser-specific token data should live in DynamoDB, while SSM should be reserved for system configuration and secrets.\n\nValidation:\n- pnpm lint\n- pnpm typecheck\n- pnpm build\n- pnpm test