### PR TITLE
fix(api): reauthorize Graph subscriptions on lifecycle events

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -264,11 +264,11 @@ Microsoft Graph change notification subscriptions expire every 3 days (maximum).
 
 Microsoft sends lifecycle events to a dedicated `lifecycleNotificationUrl`, handled by the **Lifecycle Notification Lambda** (separate from the webhook receiver):
 
-| Lifecycle event           | Action                                                                                                                                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Lifecycle event           | Action                                                                                                                                                                                                                                                |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `reauthorizationRequired` | Lambda reads the user's refresh token from DynamoDB, performs token refresh, stores rotated tokens back to DynamoDB, then calls `POST /subscriptions/{id}/reauthorize`. If reauthorization fails, marks OneDrive as `reconnect_required` in DynamoDB. |
-| `subscriptionRemoved`     | Marks OneDrive as `disconnected` in DynamoDB immediately.                                                                                                                                                          |
-| `missed`                  | Logs to CloudWatch; Processor Lambda will catch up on next manual sync.                                                                                                                                            |
+| `subscriptionRemoved`     | Marks OneDrive as `disconnected` in DynamoDB immediately.                                                                                                                                                                                             |
+| `missed`                  | Logs to CloudWatch; Processor Lambda will catch up on next manual sync.                                                                                                                                                                               |
 
 #### Microsoft Graph source of truth (verify before changing behavior)
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -266,11 +266,19 @@ Microsoft sends lifecycle events to a dedicated `lifecycleNotificationUrl`, hand
 
 | Lifecycle event           | Action                                                                                                                                                                                                             |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `reauthorizationRequired` | Lambda reads the user's refresh token from DynamoDB, performs token refresh, stores rotated tokens back to DynamoDB, then renews the subscription. If renewal fails, marks OneDrive as `disconnected` in DynamoDB. |
+| `reauthorizationRequired` | Lambda reads the user's refresh token from DynamoDB, performs token refresh, stores rotated tokens back to DynamoDB, then calls `POST /subscriptions/{id}/reauthorize`. If reauthorization fails, marks OneDrive as `reconnect_required` in DynamoDB. |
 | `subscriptionRemoved`     | Marks OneDrive as `disconnected` in DynamoDB immediately.                                                                                                                                                          |
 | `missed`                  | Logs to CloudWatch; Processor Lambda will catch up on next manual sync.                                                                                                                                            |
 
-In all `disconnected` cases the plugin surfaces a **"Reconnect OneDrive"** prompt on its next `/status` poll, explaining the reason. There is no SNS email alert — the plugin is the primary UI for error surfacing.
+#### Microsoft Graph source of truth (verify before changing behavior)
+
+Lifecycle handling in this integration must be updated only against verified Microsoft Graph documentation, not assumptions.
+
+- Lifecycle notifications and required app actions: https://learn.microsoft.com/en-us/graph/change-notifications-lifecycle-events
+- `POST /subscriptions/{id}/reauthorize` reference: https://learn.microsoft.com/en-us/graph/api/subscription-reauthorize?view=graph-rest-1.0
+- Subscription update (`PATCH /subscriptions/{id}`) reference: https://learn.microsoft.com/en-us/graph/api/subscription-update?view=graph-rest-1.0
+
+In all `disconnected` and `reconnect_required` cases the plugin surfaces a **"Reconnect OneDrive"** prompt on its next `/status` poll, explaining the reason. There is no SNS email alert — the plugin is the primary UI for error surfacing.
 
 ---
 

--- a/packages/api/src/onedrive-lifecycle.test.ts
+++ b/packages/api/src/onedrive-lifecycle.test.ts
@@ -96,7 +96,7 @@ describe("POST /onedrive/lifecycle", () => {
     expect(updateCommand.input.ExpressionAttributeValues[":status"]).toBe("reconnect_required");
   });
 
-  it("refreshes the token and renews the subscription for reauthorizationRequired events", async () => {
+  it("refreshes the token and reauthorizes the subscription for reauthorizationRequired events", async () => {
     setupDbMock([
       { command: GetCommand, response: { Item: { refreshToken: "existing-refresh-token" } } },
     ]);
@@ -112,14 +112,9 @@ describe("POST /onedrive/lifecycle", () => {
             }),
         } as Response);
       }
-      if (url === "https://graph.microsoft.com/v1.0/subscriptions/sub-123") {
+      if (url === "https://graph.microsoft.com/v1.0/subscriptions/sub-123/reauthorize") {
         return Promise.resolve({
           ok: true,
-          json: () =>
-            Promise.resolve({
-              id: "sub-123",
-              expirationDateTime: "2026-04-14T00:00:00.000Z",
-            }),
         } as Response);
       }
       return Promise.reject(new Error(`Unexpected fetch: ${url}`));
@@ -151,14 +146,14 @@ describe("POST /onedrive/lifecycle", () => {
 
     const renewCall = await vi.waitFor(() => {
       const call = mockFetch.mock.calls.find(
-        ([url]) => url === "https://graph.microsoft.com/v1.0/subscriptions/sub-123",
+        ([url]) => url === "https://graph.microsoft.com/v1.0/subscriptions/sub-123/reauthorize",
       );
       expect(call).toBeDefined();
       return call;
     });
 
     const [, renewOptions] = renewCall as [string, RequestInit];
-    expect(renewOptions.method).toBe("PATCH");
+    expect(renewOptions.method).toBe("POST");
     expect((renewOptions.headers as { [key: string]: string })["Authorization"]).toBe(
       "Bearer new-access-token",
     );
@@ -246,7 +241,7 @@ describe("POST /onedrive/lifecycle", () => {
     expect(updateCommand.input.ExpressionAttributeValues[":status"]).toBe("reconnect_required");
   });
 
-  it("marks the user as reconnect_required when subscription renewal fails", async () => {
+  it("marks the user as reconnect_required when subscription reauthorization fails", async () => {
     setupDbMock([
       { command: GetCommand, response: { Item: { refreshToken: "existing-refresh-token" } } },
     ]);
@@ -262,7 +257,7 @@ describe("POST /onedrive/lifecycle", () => {
             }),
         } as Response);
       }
-      if (url === "https://graph.microsoft.com/v1.0/subscriptions/sub-456") {
+      if (url === "https://graph.microsoft.com/v1.0/subscriptions/sub-456/reauthorize") {
         return Promise.resolve({
           ok: false,
           status: 500,
@@ -345,14 +340,9 @@ describe("POST /onedrive/lifecycle", () => {
             }),
         } as Response);
       }
-      if (url === "https://graph.microsoft.com/v1.0/subscriptions/sub-123") {
+      if (url === "https://graph.microsoft.com/v1.0/subscriptions/sub-123/reauthorize") {
         return Promise.resolve({
           ok: true,
-          json: () =>
-            Promise.resolve({
-              id: "sub-123",
-              expirationDateTime: "2026-04-14T00:00:00.000Z",
-            }),
         } as Response);
       }
       return Promise.reject(new Error(`Unexpected fetch: ${url}`));

--- a/packages/api/src/onedrive-lifecycle.ts
+++ b/packages/api/src/onedrive-lifecycle.ts
@@ -80,44 +80,29 @@ async function markReconnectRequired(userId: string): Promise<void> {
   await updateOneDriveStatus(userId, "reconnect_required");
 }
 
-interface GraphSubscriptionResponse {
-  expirationDateTime: string;
-}
-
 interface MicrosoftTokenResponse {
   access_token: string;
   refresh_token: string;
   expires_in: number;
 }
 
-function parseGraphSubscriptionResponse(value: unknown): GraphSubscriptionResponse {
-  if (!isRecord(value) || typeof value["expirationDateTime"] !== "string") {
-    throw new Error("Invalid Graph subscription response shape");
-  }
-
-  return { expirationDateTime: value["expirationDateTime"] };
-}
-
-async function renewGraphSubscription(
+async function reauthorizeGraphSubscription(
   subscriptionId: string,
   accessToken: string,
-): Promise<string> {
-  const expirationDateTime = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
-  const response = await fetch(`https://graph.microsoft.com/v1.0/subscriptions/${subscriptionId}`, {
-    method: "PATCH",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
+): Promise<void> {
+  const response = await fetch(
+    `https://graph.microsoft.com/v1.0/subscriptions/${subscriptionId}/reauthorize`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
     },
-    body: JSON.stringify({ expirationDateTime }),
-  });
+  );
 
   if (!response.ok) {
-    throw new Error(`Graph subscription renewal failed: ${response.status} ${response.statusText}`);
+    throw new Error(`Graph subscription reauthorize failed: ${response.status} ${response.statusText}`);
   }
-
-  const data = parseGraphSubscriptionResponse(await response.json());
-  return data.expirationDateTime;
 }
 
 function parseMicrosoftTokenResponse(value: unknown): MicrosoftTokenResponse {
@@ -156,7 +141,9 @@ async function refreshUserToken(refreshToken: string): Promise<MicrosoftTokenRes
 
   const response = await fetch("https://login.microsoftonline.com/common/oauth2/v2.0/token", {
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
     body: body.toString(),
   });
   if (!response.ok) {
@@ -211,7 +198,7 @@ async function handleReauthorizationRequired(notification: LifecycleNotification
     refreshed.refresh_token,
     refreshed.expires_in,
   );
-  await renewGraphSubscription(notification.subscriptionId, refreshed.access_token);
+  await reauthorizeGraphSubscription(notification.subscriptionId, refreshed.access_token);
   await markConnected(notification.clientState);
 }
 

--- a/packages/api/src/onedrive-lifecycle.ts
+++ b/packages/api/src/onedrive-lifecycle.ts
@@ -101,7 +101,9 @@ async function reauthorizeGraphSubscription(
   );
 
   if (!response.ok) {
-    throw new Error(`Graph subscription reauthorize failed: ${response.status} ${response.statusText}`);
+    throw new Error(
+      `Graph subscription reauthorize failed: ${response.status} ${response.statusText}`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- switch lifecycle handling for reauthorizationRequired from PATCH renew to POST /subscriptions/<id>/reauthorize
- update lifecycle tests to assert reauthorize endpoint usage and POST method
- document Microsoft Graph lifecycle source-of-truth links and requirement to verify docs before behavior changes

## Validation
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test