### PR TITLE
fix(api): request Files.ReadWrite for OneDrive lifecycle reauth

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -187,7 +187,7 @@ Connecting OneDrive is a separate, explicit step after logging in. It uses Micro
 | Type                    | Multi-tenant, public client                          |
 | Supported account types | Personal Microsoft accounts AND work/school accounts |
 | Redirect URI            | `obsidian://petroglyph/oauth/callback`               |
-| Scopes                  | `Files.Read offline_access`                          |
+| Scopes                  | `Files.ReadWrite offline_access`                     |
 
 > Supports both personal accounts (outlook.com, hotmail.com, live.com) and work/school accounts (Microsoft 365 / Entra ID). Multi-tenant registration is required for personal account support.
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -165,7 +165,7 @@ Used for OneDrive connection (`GET /onedrive/auth-url` → `GET /onedrive/connec
 
 3. Click **Register**. Copy the **Application (client) ID** from the overview page.
 4. Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**. Add:
-   - `Files.Read`
+   - `Files.ReadWrite`
    - `offline_access`
 5. Go to **Certificates & secrets → New client secret**. Copy the **Value** immediately (it is only shown once).
 6. Store in SSM (overwrite the placeholder):

--- a/packages/api/src/onedrive-auth-url.test.ts
+++ b/packages/api/src/onedrive-auth-url.test.ts
@@ -67,7 +67,7 @@ describe("GET /onedrive/auth-url", () => {
     expect(url.searchParams.get("client_id")).toBe("test-ms-client-id");
     expect(url.searchParams.get("response_type")).toBe("code");
     expect(url.searchParams.get("redirect_uri")).toBe("obsidian://petroglyph/onedrive/callback");
-    expect(url.searchParams.get("scope")).toBe("files.read offline_access");
+    expect(url.searchParams.get("scope")).toBe("files.readwrite offline_access");
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
     expect(url.searchParams.get("state")).toBeTruthy();
     expect(url.searchParams.get("code_challenge")).toBeTruthy();

--- a/packages/api/src/onedrive-auth-url.ts
+++ b/packages/api/src/onedrive-auth-url.ts
@@ -41,7 +41,7 @@ export async function handleOnedriveAuthUrl(
   url.searchParams.set("client_id", clientId);
   url.searchParams.set("response_type", "code");
   url.searchParams.set("redirect_uri", redirectUri);
-  url.searchParams.set("scope", "files.read offline_access");
+  url.searchParams.set("scope", "files.readwrite offline_access");
   url.searchParams.set("state", state);
   url.searchParams.set("code_challenge", challenge);
   url.searchParams.set("code_challenge_method", "S256");

--- a/packages/api/src/onedrive-connect.test.ts
+++ b/packages/api/src/onedrive-connect.test.ts
@@ -260,7 +260,7 @@ describe("POST /onedrive/connect", () => {
     expect(sentParams.get("code")).toBe(VALID_CODE);
     expect(sentParams.get("redirect_uri")).toBe("obsidian://petroglyph/onedrive/callback");
     expect(sentParams.get("code_verifier")).toBe(VALID_VERIFIER);
-    expect(sentParams.get("scope")).toBe("files.read offline_access");
+    expect(sentParams.get("scope")).toBe("files.readwrite offline_access");
   });
 
   it("returns 500 when MICROSOFT_CLIENT_SECRET is not configured", async () => {

--- a/packages/api/src/onedrive-connect.ts
+++ b/packages/api/src/onedrive-connect.ts
@@ -112,7 +112,7 @@ async function exchangeCodeForTokens(
     code,
     redirect_uri: redirectUri,
     code_verifier: verifier,
-    scope: "files.read offline_access",
+    scope: "files.readwrite offline_access",
   });
 
   const response = await fetch("https://login.microsoftonline.com/common/oauth2/v2.0/token", {

--- a/packages/api/src/onedrive-lifecycle.ts
+++ b/packages/api/src/onedrive-lifecycle.ts
@@ -138,7 +138,7 @@ async function refreshUserToken(refreshToken: string): Promise<MicrosoftTokenRes
     client_secret: clientSecret,
     grant_type: "refresh_token",
     refresh_token: refreshToken,
-    scope: "files.read offline_access",
+    scope: "files.readwrite offline_access",
   });
 
   const response = await fetch("https://login.microsoftonline.com/common/oauth2/v2.0/token", {

--- a/packages/api/src/onedrive-middleware.test.ts
+++ b/packages/api/src/onedrive-middleware.test.ts
@@ -138,7 +138,7 @@ describe("onedriveMiddleware", () => {
       expect(params.get("client_secret")).toBe("test-client-secret");
       expect(params.get("grant_type")).toBe("refresh_token");
       expect(params.get("refresh_token")).toBe(REFRESH_TOKEN);
-      expect(params.get("scope")).toBe("files.read offline_access");
+      expect(params.get("scope")).toBe("files.readwrite offline_access");
     });
 
     it("writes new tokens back to DynamoDB", async () => {

--- a/packages/api/src/onedrive-middleware.ts
+++ b/packages/api/src/onedrive-middleware.ts
@@ -83,7 +83,7 @@ export async function refreshOneDriveToken(
     client_secret: clientSecret,
     grant_type: "refresh_token",
     refresh_token: currentRefreshToken,
-    scope: "files.read offline_access",
+    scope: "files.readwrite offline_access",
   });
 
   const response = await fetch("https://login.microsoftonline.com/common/oauth2/v2.0/token", {

--- a/packages/processor/src/index.test.ts
+++ b/packages/processor/src/index.test.ts
@@ -294,7 +294,7 @@ describe("processor handler", () => {
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
         },
-        body: "client_id=test-microsoft-client-id&grant_type=refresh_token&refresh_token=stale-refresh-token&scope=files.read+offline_access",
+        body: "client_id=test-microsoft-client-id&grant_type=refresh_token&refresh_token=stale-refresh-token&scope=files.readwrite+offline_access",
       },
     ]);
 

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -172,7 +172,7 @@ async function refreshOneDriveAccessToken(refreshToken: string): Promise<string>
       client_id: clientId,
       grant_type: "refresh_token",
       refresh_token: refreshToken,
-      scope: "files.read offline_access",
+      scope: "files.readwrite offline_access",
     }).toString(),
   });
 


### PR DESCRIPTION
## Why
Graph lifecycle reauthorization for our OneDrive subscription still returns 308 under the current token scope.
Microsoft Graph docs list driveItem lifecycle reauthorization support under Files.ReadWrite for personal OneDrive delegated access rather than Files.Read.

## Changes
- request files.readwrite offline_access in all OneDrive OAuth/token refresh flows
  - auth URL generation
  - code exchange
  - middleware refresh
  - lifecycle refresh
  - processor refresh
- update tests to match the new scope payloads
- update integration and ops docs to require Files.ReadWrite

## Operational note
Existing tokens granted only with Files.Read will need reconnect and reauthorization to grant Files.ReadWrite before lifecycle reauthorization can succeed.

## Validation
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test