### PR TITLE
fix(api): surface OneDrive OAuth callback errors

### DIFF
--- a/packages/api/src/onedrive-connect.test.ts
+++ b/packages/api/src/onedrive-connect.test.ts
@@ -488,6 +488,22 @@ describe("GET /onedrive/connect", () => {
     );
   });
 
+  it("redirects OAuth errors to obsidian:// callback with error and state", async () => {
+    const res = await app.request(
+      `/onedrive/connect?error=server_error&state=${VALID_STATE}&error_description=Something+went+wrong`,
+      {
+        method: "GET",
+      },
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("Location");
+    expect(location).toContain("obsidian://petroglyph/oauth/callback?");
+    expect(location).toContain("error=server_error");
+    expect(location).toContain(`state=${VALID_STATE}`);
+    expect(location).toContain("error_description=Something+went+wrong");
+  });
+
   // ── Missing query params ──────────────────────────────────────────────────
 
   it("returns 400 when code query param is missing", async () => {

--- a/packages/api/src/onedrive-connect.ts
+++ b/packages/api/src/onedrive-connect.ts
@@ -247,6 +247,22 @@ async function upsertSyncProfile(userId: string): Promise<void> {
 }
 
 export function handleOnedriveCallbackBridge(c: Context<{ Variables: AppVariables }>): Response {
+  const oauthError = c.req.query("error");
+  const oauthErrorDescription = c.req.query("error_description");
+  const stateFromError = c.req.query("state");
+
+  if (oauthError && oauthError.length > 0) {
+    const redirectUrl = new URL("obsidian://petroglyph/oauth/callback");
+    redirectUrl.searchParams.set("error", oauthError);
+    if (stateFromError && stateFromError.length > 0) {
+      redirectUrl.searchParams.set("state", stateFromError);
+    }
+    if (oauthErrorDescription && oauthErrorDescription.length > 0) {
+      redirectUrl.searchParams.set("error_description", oauthErrorDescription);
+    }
+    return c.redirect(redirectUrl.toString(), 302);
+  }
+
   const code = c.req.query("code");
   const state = c.req.query("state");
 


### PR DESCRIPTION
## Summary
- handle Microsoft OAuth callback errors on GET /onedrive/connect when error is present
- redirect error payload to obsidian://petroglyph/oauth/callback with error, state, and optional error_description
- keep existing code/state success path unchanged
- add tests for OAuth error redirect behavior

## Why
Microsoft can redirect with error and no code (for example error=server_error).
Previously this returned a misleading API JSON error (Missing required query param: code) instead of forwarding the OAuth failure to the plugin callback flow.

## Validation
- pnpm --filter @petroglyph/api test -- onedrive-connect