### PR TITLE
Add local OneDrive flow harness and harnessCallbackUri support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ test-output.txt
 .terraform.tfstate.lock.info
 .ralph-state.json
 .ralph-*.log
+.worktrees/

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -278,6 +278,24 @@ Lifecycle handling in this integration must be updated only against verified Mic
 - `POST /subscriptions/{id}/reauthorize` reference: https://learn.microsoft.com/en-us/graph/api/subscription-reauthorize?view=graph-rest-1.0
 - Subscription update (`PATCH /subscriptions/{id}`) reference: https://learn.microsoft.com/en-us/graph/api/subscription-update?view=graph-rest-1.0
 
+### Local OneDrive flow harness
+
+For debugging the end-to-end auth sequence without the Obsidian plugin UI, Petroglyph includes a local harness:
+
+```sh
+pnpm --filter @petroglyph/api local-onedrive-flow
+```
+
+The harness follows the same request flow as the app:
+
+1. `GET /auth/url` and `GET /auth/callback` to mint local GitHub credentials.
+2. `GET /onedrive/auth-url` to start OneDrive auth.
+3. `GET /onedrive/connect?code=...&state=...` to inspect the callback bridge response.
+4. `POST /onedrive/connect` to complete the OneDrive connection.
+5. `POST /auth/refresh` to mint a fresh JWT and confirm the refresh path still works.
+
+It stores its local state in `.working-docs/local-onedrive-flow.json` by default. The API must be started with `MICROSOFT_REDIRECT_URI` pointing at the harness callback server (default port `8787`), so Microsoft can return the OneDrive auth code locally.
+
 In all `disconnected` and `reconnect_required` cases the plugin surfaces a **"Reconnect OneDrive"** prompt on its next `/status` poll, explaining the reason. There is no SNS email alert — the plugin is the primary UI for error surfacing.
 
 ---

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,6 +17,7 @@
     "generate-types": "openapi-typescript openapi.yaml -o src/openapi-types.ts",
     "lint": "eslint .",
     "prebuild": "pnpm generate-types",
+    "local-onedrive-flow": "tsx scripts/local-onedrive-flow.ts",
     "smoke-test": "tsx scripts/smoke-test.ts",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"

--- a/packages/api/scripts/local-onedrive-flow.test.ts
+++ b/packages/api/scripts/local-onedrive-flow.test.ts
@@ -1,0 +1,183 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { parseArgs, readLocalState, runLocalFlow, writeLocalState } from "./local-onedrive-flow.js";
+
+describe("local-onedrive-flow helpers", () => {
+  it("parses CLI arguments", () => {
+    const args = parseArgs([
+      "--api-base-url",
+      "http://127.0.0.1:3000",
+      "--state-path",
+      "/tmp/petroglyph-flow.json",
+      "--callback-port",
+      "9001",
+      "--no-open",
+    ]);
+
+    expect(args).toEqual({
+      apiBaseUrl: "http://127.0.0.1:3000",
+      statePath: "/tmp/petroglyph-flow.json",
+      callbackPort: 9001,
+      noOpen: true,
+    });
+  });
+
+  it("round-trips local state to disk", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "petroglyph-flow-"));
+    const statePath = join(dir, "state.json");
+
+    try {
+      expect(await readLocalState(statePath)).toEqual({});
+
+      await writeLocalState(statePath, {
+        github: {
+          jwt: "jwt-1",
+          refreshToken: "refresh-1",
+          username: "alice",
+        },
+        oneDrive: {
+          connected: true,
+          lastStatus: "connected",
+        },
+      });
+
+      const persisted = await readLocalState(statePath);
+      expect(persisted.github?.username).toBe("alice");
+      expect(persisted.oneDrive?.connected).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("runs the local auth and refresh flow", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "petroglyph-flow-"));
+    const statePath = join(dir, "state.json");
+    const openBrowser = vi.fn((): Promise<void> => Promise.resolve());
+    const githubCallback = {
+      jwt: "jwt-1",
+      refreshToken: "refresh-1",
+      username: "alice",
+    };
+    const oneDriveCallback = {
+      code: "code-1",
+      state: "state-1",
+    };
+    const waitForGithubCallback = vi.fn(() => Promise.resolve(githubCallback));
+    const waitForOneDriveCallback = vi.fn(() => Promise.resolve(oneDriveCallback));
+
+    const fetchFn = vi.fn(
+      (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+        if (url.startsWith("http://api.example.test/auth/url")) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ url: "https://github.example.test/auth" }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
+        }
+
+        if (url.startsWith("http://api.example.test/onedrive/auth-url")) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ url: "https://login.microsoftonline.com/auth" }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
+        }
+
+        if (url === "http://api.example.test/onedrive/connect" && init?.method === "POST") {
+          return Promise.resolve(
+            new Response(JSON.stringify({ status: "connected" }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
+        }
+
+        if (url === "http://api.example.test/status") {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                github: { connected: true, username: "alice" },
+                oneDrive: { connected: true },
+                oneDriveStatus: "connected",
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            ),
+          );
+        }
+
+        if (url === "http://api.example.test/auth/refresh" && init?.method === "POST") {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                jwt: "jwt-2",
+                refreshToken: "refresh-2",
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            ),
+          );
+        }
+
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      },
+    );
+
+    try {
+      const state = await runLocalFlow({
+        apiBaseUrl: "http://api.example.test",
+        statePath,
+        callbackPort: 8787,
+        openBrowser,
+        fetchFn,
+        callbacks: {
+          githubCallbackUrl: "http://127.0.0.1:8787/github-callback",
+          oneDriveCallbackUrl: "http://127.0.0.1:8787/onedrive-callback",
+          waitForGithubCallback,
+          waitForOneDriveCallback,
+          close: () => Promise.resolve(),
+        },
+      });
+
+      expect(openBrowser).toHaveBeenCalledTimes(2);
+      expect(waitForGithubCallback).toHaveBeenCalledTimes(1);
+      expect(waitForOneDriveCallback).toHaveBeenCalledTimes(1);
+      expect(fetchFn).toHaveBeenCalledWith(
+        "http://api.example.test/auth/url?returnUri=http%3A%2F%2F127.0.0.1%3A8787%2Fgithub-callback",
+        undefined,
+      );
+      expect(fetchFn).toHaveBeenCalledWith(
+        "http://api.example.test/onedrive/auth-url?harnessCallbackUri=http%3A%2F%2F127.0.0.1%3A8787%2Fonedrive-callback",
+        expect.objectContaining({ headers: { Authorization: "Bearer jwt-1" } }),
+      );
+      expect(fetchFn).not.toHaveBeenCalledWith(
+        expect.stringContaining("onedrive/connect?"),
+        expect.anything(),
+      );
+      expect(state.github?.jwt).toBe("jwt-2");
+      expect(state.github?.refreshToken).toBe("refresh-2");
+      expect(state.oneDrive?.connected).toBe(true);
+
+      const persisted = JSON.parse(await readFile(statePath, "utf8")) as {
+        github?: { jwt?: string; refreshToken?: string; username?: string };
+        oneDrive?: { connected?: boolean; lastStatus?: string };
+      };
+      expect(persisted.github?.username).toBe("alice");
+      expect(persisted.github?.jwt).toBe("jwt-2");
+      expect(persisted.oneDrive?.lastStatus).toBe("connected");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/api/scripts/local-onedrive-flow.ts
+++ b/packages/api/scripts/local-onedrive-flow.ts
@@ -1,0 +1,465 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { spawn } from "node:child_process";
+
+interface GitHubCallbackPayload {
+  jwt: string;
+  refreshToken: string;
+  username: string;
+}
+
+interface OneDriveCallbackPayload {
+  code: string;
+  state: string;
+  error?: string;
+  errorDescription?: string;
+}
+
+interface LocalFlowState {
+  github?: GitHubCallbackPayload;
+  oneDrive?: {
+    connected: boolean;
+    lastStatus?: string;
+  };
+  updatedAt?: string;
+}
+
+interface FlowCallbacks {
+  githubCallbackUrl: string;
+  oneDriveCallbackUrl: string;
+  waitForGithubCallback: () => Promise<GitHubCallbackPayload>;
+  waitForOneDriveCallback: () => Promise<OneDriveCallbackPayload>;
+  close: () => Promise<void>;
+}
+
+interface LocalFlowOptions {
+  apiBaseUrl: string;
+  statePath: string;
+  callbackPort: number;
+  openBrowser?: (url: string) => Promise<void>;
+  fetchFn?: typeof fetch;
+  callbacks: FlowCallbacks;
+}
+
+interface AuthUrlResponse {
+  url: string;
+}
+
+interface OnedriveConnectResponse {
+  status: string;
+}
+
+interface AuthRefreshResponse {
+  jwt: string;
+  refreshToken: string;
+}
+
+interface StatusResponse {
+  oneDriveStatus: string;
+  oneDrive: {
+    connected: boolean;
+  };
+  github: {
+    connected: boolean;
+    username?: string;
+  };
+}
+
+interface ParsedArgs {
+  apiBaseUrl: string;
+  statePath: string;
+  callbackPort: number;
+  noOpen: boolean;
+}
+
+const DEFAULT_API_BASE_URL = process.env["PETROGLYPH_API_BASE_URL"] ?? "http://localhost:3000";
+const DEFAULT_CALLBACK_PORT = Number(process.env["PETROGLYPH_LOCAL_FLOW_PORT"] ?? "8787");
+const DEFAULT_STATE_PATH =
+  process.env["PETROGLYPH_LOCAL_FLOW_STATE_PATH"] ??
+  join(process.cwd(), ".working-docs", "local-onedrive-flow.json");
+
+function isRecord(value: unknown): value is { [key: string]: unknown } {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function parseCallbackPayload(url: URL): GitHubCallbackPayload | OneDriveCallbackPayload {
+  const error = stringOrUndefined(url.searchParams.get("error"));
+  const errorDescription = stringOrUndefined(url.searchParams.get("error_description"));
+  const code = stringOrUndefined(url.searchParams.get("code"));
+  const state = stringOrUndefined(url.searchParams.get("state"));
+  const jwt = stringOrUndefined(url.searchParams.get("jwt"));
+  const refreshToken = stringOrUndefined(url.searchParams.get("refreshToken"));
+  const username = stringOrUndefined(url.searchParams.get("username"));
+
+  if (jwt !== undefined && refreshToken !== undefined && username !== undefined) {
+    return { jwt, refreshToken, username };
+  }
+
+  if (code === undefined || state === undefined) {
+    throw new Error(`Callback missing code/state: ${url.toString()}`);
+  }
+
+  return {
+    code,
+    state,
+    ...(error !== undefined ? { error } : {}),
+    ...(errorDescription !== undefined ? { errorDescription } : {}),
+  };
+}
+
+async function requestJson<T>(fetchFn: typeof fetch, url: string, init?: RequestInit): Promise<T> {
+  const response = await fetchFn(url, init);
+  const bodyText = await response.text();
+
+  if (!response.ok) {
+    throw new Error(`${url} returned ${response.status} ${response.statusText}: ${bodyText}`);
+  }
+
+  return JSON.parse(bodyText) as T;
+}
+
+function renderCallbackPage(title: string, details: string): string {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+  </head>
+  <body>
+    <h1>${title}</h1>
+    <pre>${details}</pre>
+    <p>You can close this tab.</p>
+  </body>
+</html>`;
+}
+
+async function ensureParentDir(path: string): Promise<void> {
+  await mkdir(join(path, ".."), { recursive: true });
+}
+
+export async function readLocalState(statePath: string): Promise<LocalFlowState> {
+  try {
+    const raw = await readFile(statePath, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    return isRecord(parsed) ? (parsed as LocalFlowState) : {};
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as { code?: string }).code === "ENOENT"
+    ) {
+      return {};
+    }
+    throw error;
+  }
+}
+
+export async function writeLocalState(statePath: string, state: LocalFlowState): Promise<void> {
+  await ensureParentDir(statePath);
+  await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+function startBrowser(url: string): Promise<void> {
+  const browser = process.env["BROWSER"];
+  const command =
+    browser ??
+    (process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open");
+  const args =
+    process.platform === "win32" && browser === undefined ? ["/c", "start", "", url] : [url];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "ignore", detached: true });
+    child.on("error", reject);
+    child.unref();
+    resolve();
+  });
+}
+
+export async function startFlowCallbacks(callbackPort: number): Promise<FlowCallbacks> {
+  const pendingGithub: Array<(payload: GitHubCallbackPayload) => void> = [];
+  const pendingOneDrive: Array<(payload: OneDriveCallbackPayload) => void> = [];
+  let githubResolved: GitHubCallbackPayload | undefined;
+  let oneDriveResolved: OneDriveCallbackPayload | undefined;
+
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const requestUrl = new URL(req.url ?? "/", `http://127.0.0.1:${callbackPort}`);
+    const pathname = requestUrl.pathname;
+
+    if (pathname !== "/github-callback" && pathname !== "/onedrive-callback") {
+      res.statusCode = 404;
+      res.end("Not found");
+      return;
+    }
+
+    const payload = parseCallbackPayload(requestUrl);
+
+    if ("jwt" in payload) {
+      githubResolved = payload;
+      while (pendingGithub.length > 0) {
+        const resolve = pendingGithub.shift();
+        if (resolve) resolve(payload);
+      }
+    } else {
+      oneDriveResolved = payload;
+      while (pendingOneDrive.length > 0) {
+        const resolve = pendingOneDrive.shift();
+        if (resolve) resolve(payload);
+      }
+    }
+
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.end(
+      renderCallbackPage(
+        pathname === "/github-callback" ? "GitHub connected" : "OneDrive callback received",
+        JSON.stringify(payload, null, 2),
+      ),
+    );
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(callbackPort, "127.0.0.1", resolve);
+  });
+
+  return {
+    githubCallbackUrl: `http://127.0.0.1:${callbackPort}/github-callback`,
+    oneDriveCallbackUrl: `http://127.0.0.1:${callbackPort}/onedrive-callback`,
+    waitForGithubCallback: () =>
+      new Promise<GitHubCallbackPayload>((resolve) => {
+        if (githubResolved !== undefined) {
+          resolve(githubResolved);
+          return;
+        }
+        pendingGithub.push(resolve);
+      }),
+    waitForOneDriveCallback: () =>
+      new Promise<OneDriveCallbackPayload>((resolve) => {
+        if (oneDriveResolved !== undefined) {
+          resolve(oneDriveResolved);
+          return;
+        }
+        pendingOneDrive.push(resolve);
+      }),
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+  };
+}
+
+async function openBrowserOrPrint(
+  url: string,
+  openBrowser?: (url: string) => Promise<void>,
+): Promise<void> {
+  try {
+    if (openBrowser !== undefined) {
+      await openBrowser(url);
+      return;
+    }
+    await startBrowser(url);
+  } catch {
+    console.log(`Open this URL manually:\n${url}`);
+  }
+}
+
+async function runGitHubLogin(options: LocalFlowOptions): Promise<GitHubCallbackPayload> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const authUrl = new URL("/auth/url", options.apiBaseUrl);
+  authUrl.searchParams.set("returnUri", options.callbacks.githubCallbackUrl);
+
+  const authUrlResponse = await requestJson<AuthUrlResponse>(fetchFn, authUrl.toString());
+  await openBrowserOrPrint(authUrlResponse.url, options.openBrowser);
+
+  const callback = await options.callbacks.waitForGithubCallback();
+  return callback;
+}
+
+async function runOneDriveConnect(
+  options: LocalFlowOptions,
+  jwt: string,
+): Promise<OnedriveConnectResponse> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const authUrl = new URL("/onedrive/auth-url", options.apiBaseUrl);
+  authUrl.searchParams.set("harnessCallbackUri", options.callbacks.oneDriveCallbackUrl);
+  const authUrlResponse = await requestJson<AuthUrlResponse>(fetchFn, authUrl.toString(), {
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+
+  await openBrowserOrPrint(authUrlResponse.url, options.openBrowser);
+
+  const callback = await options.callbacks.waitForOneDriveCallback();
+  if (callback.error !== undefined) {
+    throw new Error(
+      callback.errorDescription !== undefined
+        ? `${callback.error}: ${callback.errorDescription}`
+        : callback.error,
+    );
+  }
+
+  const connectResponse = await requestJson<OnedriveConnectResponse>(
+    fetchFn,
+    new URL("/onedrive/connect", options.apiBaseUrl).toString(),
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ code: callback.code, state: callback.state }),
+    },
+  );
+
+  return connectResponse;
+}
+
+async function refreshJwt(
+  options: LocalFlowOptions,
+  refreshToken: string,
+): Promise<AuthRefreshResponse> {
+  const fetchFn = options.fetchFn ?? fetch;
+  return requestJson<AuthRefreshResponse>(
+    fetchFn,
+    new URL("/auth/refresh", options.apiBaseUrl).toString(),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ refreshToken }),
+    },
+  );
+}
+
+async function fetchStatus(options: LocalFlowOptions, jwt: string): Promise<StatusResponse> {
+  const fetchFn = options.fetchFn ?? fetch;
+  return requestJson<StatusResponse>(fetchFn, new URL("/status", options.apiBaseUrl).toString(), {
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    apiBaseUrl: DEFAULT_API_BASE_URL,
+    statePath: DEFAULT_STATE_PATH,
+    callbackPort: DEFAULT_CALLBACK_PORT,
+    noOpen: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--api-base-url") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("--api-base-url requires a value");
+      parsed.apiBaseUrl = value;
+      i += 1;
+      continue;
+    }
+    if (arg === "--state-path") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("--state-path requires a value");
+      parsed.statePath = value;
+      i += 1;
+      continue;
+    }
+    if (arg === "--callback-port") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("--callback-port requires a value");
+      const port = Number(value);
+      if (!Number.isInteger(port) || port <= 0) {
+        throw new Error("--callback-port must be a positive integer");
+      }
+      parsed.callbackPort = port;
+      i += 1;
+      continue;
+    }
+    if (arg === "--no-open") {
+      parsed.noOpen = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return parsed;
+}
+
+export async function runLocalFlow(options: LocalFlowOptions): Promise<LocalFlowState> {
+  const currentState = await readLocalState(options.statePath);
+  const nextState: LocalFlowState = { ...currentState };
+
+  const github = await runGitHubLogin(options);
+  nextState.github = github;
+  nextState.updatedAt = new Date().toISOString();
+  await writeLocalState(options.statePath, nextState);
+
+  const connectResponse = await runOneDriveConnect(options, github.jwt);
+  nextState.oneDrive = {
+    connected: connectResponse.status === "connected",
+    lastStatus: connectResponse.status,
+  };
+  nextState.updatedAt = new Date().toISOString();
+  await writeLocalState(options.statePath, nextState);
+
+  const status = await fetchStatus(options, github.jwt);
+  if (!status.oneDrive.connected) {
+    throw new Error(`Expected OneDrive to be connected, got ${status.oneDriveStatus}`);
+  }
+
+  const refreshed = await refreshJwt(options, github.refreshToken);
+  nextState.github = {
+    jwt: refreshed.jwt,
+    refreshToken: refreshed.refreshToken,
+    username: github.username,
+  };
+  nextState.updatedAt = new Date().toISOString();
+  await writeLocalState(options.statePath, nextState);
+
+  return nextState;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const callbacks = await startFlowCallbacks(args.callbackPort);
+
+  try {
+    const flowOptions: LocalFlowOptions = {
+      apiBaseUrl: args.apiBaseUrl,
+      statePath: args.statePath,
+      callbackPort: args.callbackPort,
+      callbacks,
+      fetchFn: fetch,
+    };
+
+    if (args.noOpen) {
+      flowOptions.openBrowser = (url: string) => {
+        console.log(`Open this URL manually:\n${url}`);
+        return Promise.resolve();
+      };
+    }
+
+    const state = await runLocalFlow(flowOptions);
+
+    console.log(JSON.stringify(state, null, 2));
+  } finally {
+    await callbacks.close();
+  }
+}
+
+if (process.argv[1] !== undefined && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  await main();
+}

--- a/packages/api/src/onedrive-auth-url.test.ts
+++ b/packages/api/src/onedrive-auth-url.test.ts
@@ -142,4 +142,53 @@ describe("GET /onedrive/auth-url", () => {
     const res = await app.request("/onedrive/auth-url");
     expect(res.status).toBe(401);
   });
+
+  describe("harnessCallbackUri", () => {
+    async function getAuthUrlWithHarness(callbackUri: string): Promise<Response> {
+      const token = await makeToken();
+      return app.request(
+        `/onedrive/auth-url?harnessCallbackUri=${encodeURIComponent(callbackUri)}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+    }
+
+    it("encodes callbackUri into the state param as {uuid}|{base64url(uri)}", async () => {
+      const callbackUri = "http://127.0.0.1:8787/onedrive-callback";
+      const res = await getAuthUrlWithHarness(callbackUri);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { url: string };
+      const rawState = new URL(body.url).searchParams.get("state");
+      expect(rawState).toBeTruthy();
+      const parts = (rawState ?? "").split("|");
+      expect(parts[1]).toBeTruthy();
+      expect(Buffer.from(parts[1] ?? "", "base64url").toString("utf8")).toBe(callbackUri);
+    });
+
+    it("stores DynamoDB item with tokenHash equal to the UUID portion only (not full state)", async () => {
+      const callbackUri = "http://127.0.0.1:8787/onedrive-callback";
+      const res = await getAuthUrlWithHarness(callbackUri);
+      const body = (await res.json()) as { url: string };
+      const rawState = new URL(body.url).searchParams.get("state") ?? "";
+      const [uuid] = rawState.split("|");
+
+      const [command] = mockSend.mock.calls[0] as [{ input: { Item: { tokenHash: string } } }];
+      expect(command.input.Item.tokenHash).toBe(uuid);
+      expect(command.input.Item.tokenHash).not.toBe(rawState);
+    });
+
+    it("returns 400 when harnessCallbackUri is not a localhost URL", async () => {
+      const res = await getAuthUrlWithHarness("https://evil.example.com/callback");
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when harnessCallbackUri is not a valid URL", async () => {
+      const token = await makeToken();
+      const res = await app.request("/onedrive/auth-url?harnessCallbackUri=not-a-url", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/packages/api/src/onedrive-auth-url.ts
+++ b/packages/api/src/onedrive-auth-url.ts
@@ -1,7 +1,6 @@
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
 import type { Context } from "hono";
-import { createHash, randomBytes } from "node:crypto";
-import { randomUUID } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import type { AppVariables } from "./auth-middleware.js";
 import { docClient } from "./db.js";
 
@@ -25,15 +24,31 @@ export async function handleOnedriveAuthUrl(
     return c.json({ error: "Missing OAuth configuration" }, 500);
   }
 
+  const harnessCallbackUri = c.req.query("harnessCallbackUri");
+  if (harnessCallbackUri !== undefined) {
+    let parsedUri: URL;
+    try {
+      parsedUri = new URL(harnessCallbackUri);
+    } catch {
+      return c.json({ error: "harnessCallbackUri is not a valid URL" }, 400);
+    }
+    if (parsedUri.hostname !== "127.0.0.1" && parsedUri.hostname !== "localhost") {
+      return c.json({ error: "harnessCallbackUri must be a localhost URL" }, 400);
+    }
+  }
+
   const verifier = generateCodeVerifier();
   const challenge = generateCodeChallenge(verifier);
-  const state = randomUUID();
+  const uuid = randomUUID();
+  const state = harnessCallbackUri
+    ? `${uuid}|${Buffer.from(harnessCallbackUri).toString("base64url")}`
+    : uuid;
   const ttl = Math.floor(Date.now() / 1000) + 600;
 
   await docClient.send(
     new PutCommand({
       TableName: TABLE_NAME,
-      Item: { tokenHash: state, type: "onedrive_state", verifier, ttl },
+      Item: { tokenHash: uuid, type: "onedrive_state", verifier, ttl },
     }),
   );
 

--- a/packages/api/src/onedrive-connect.test.ts
+++ b/packages/api/src/onedrive-connect.test.ts
@@ -596,4 +596,87 @@ describe("GET /onedrive/connect", () => {
     const body = (await res.json()) as { status: string };
     expect(body.status).toBe("connected");
   });
+
+  // ── Harness callback URI ──────────────────────────────────────────────────
+
+  describe("when state encodes a harnessCallbackUri", () => {
+    const HARNESS_URI = "http://127.0.0.1:8787/onedrive-callback";
+    const HARNESS_STATE = `${VALID_STATE}|${Buffer.from(HARNESS_URI).toString("base64url")}`;
+
+    it("redirects to harnessCallbackUri instead of obsidian://", async () => {
+      const res = await app.request(
+        `/onedrive/connect?code=${VALID_CODE}&state=${encodeURIComponent(HARNESS_STATE)}`,
+        { method: "GET" },
+      );
+
+      expect(res.status).toBe(302);
+      const location = res.headers.get("Location");
+      expect(location).toContain(HARNESS_URI);
+      expect(location).toContain(`code=${VALID_CODE}`);
+      expect(location).not.toContain("obsidian://");
+    });
+
+    it("redirects OAuth errors to harnessCallbackUri instead of obsidian://", async () => {
+      const res = await app.request(
+        `/onedrive/connect?error=access_denied&state=${encodeURIComponent(HARNESS_STATE)}`,
+        { method: "GET" },
+      );
+
+      expect(res.status).toBe(302);
+      const location = res.headers.get("Location");
+      expect(location).toContain(HARNESS_URI);
+      expect(location).toContain("error=access_denied");
+      expect(location).not.toContain("obsidian://");
+    });
+  });
+});
+
+describe("POST /onedrive/connect with harness state", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.stubEnv("JWT_PUBLIC_KEY", publicKeyPem);
+    vi.stubEnv("MICROSOFT_CLIENT_ID", "test-ms-client-id");
+    vi.stubEnv("MICROSOFT_CLIENT_SECRET", "test-ms-client-secret");
+    vi.stubEnv("MICROSOFT_REDIRECT_URI", "obsidian://petroglyph/onedrive/callback");
+    vi.stubEnv("GRAPH_NOTIFICATION_URL", "https://api.example.com/graph/notify");
+    vi.stubEnv("SYNC_PROFILES_TABLE", "petroglyph-sync-profiles-test");
+    vi.stubEnv("REFRESH_TOKENS_TABLE", "petroglyph-refresh_tokens-test");
+    mockDbSend.mockClear();
+    mockFetch.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    resetKeyCache();
+  });
+
+  it("strips the harness suffix from state before DynamoDB lookup and returns connected", async () => {
+    const HARNESS_URI = "http://127.0.0.1:8787/onedrive-callback";
+    const fullState = `${VALID_STATE}|${Buffer.from(HARNESS_URI).toString("base64url")}`;
+
+    setupDynamoMock(makeStateItem());
+    setupFetchMock();
+
+    const token = await makeToken();
+    const res = await app.request("/onedrive/connect", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ code: VALID_CODE, state: fullState }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("connected");
+
+    const getCall = mockDbSend.mock.calls.find(([cmd]) => cmd instanceof GetCommand) as
+      | [{ input: { Key: { tokenHash: string } } }]
+      | undefined;
+    expect(getCall).toBeDefined();
+    expect(getCall?.[0].input.Key.tokenHash).toBe(VALID_STATE);
+  });
 });

--- a/packages/api/src/onedrive-connect.ts
+++ b/packages/api/src/onedrive-connect.ts
@@ -92,6 +92,16 @@ async function deleteStateItem(state: string): Promise<void> {
   );
 }
 
+function decodeState(state: string): { stateHash: string; callbackUri: string | undefined } {
+  const pipeIdx = state.indexOf("|");
+  if (pipeIdx === -1) {
+    return { stateHash: state, callbackUri: undefined };
+  }
+  const stateHash = state.slice(0, pipeIdx);
+  const callbackUri = Buffer.from(state.slice(pipeIdx + 1), "base64url").toString("utf8");
+  return { stateHash, callbackUri };
+}
+
 async function exchangeCodeForTokens(
   code: string,
   verifier: string,
@@ -252,7 +262,10 @@ export function handleOnedriveCallbackBridge(c: Context<{ Variables: AppVariable
   const stateFromError = c.req.query("state");
 
   if (oauthError && oauthError.length > 0) {
-    const redirectUrl = new URL("obsidian://petroglyph/oauth/callback");
+    const { callbackUri } = stateFromError
+      ? decodeState(stateFromError)
+      : { callbackUri: undefined };
+    const redirectUrl = new URL(callbackUri ?? "obsidian://petroglyph/oauth/callback");
     redirectUrl.searchParams.set("error", oauthError);
     if (stateFromError && stateFromError.length > 0) {
       redirectUrl.searchParams.set("state", stateFromError);
@@ -274,7 +287,8 @@ export function handleOnedriveCallbackBridge(c: Context<{ Variables: AppVariable
     return c.json({ error: "Missing required query param: state" }, 400);
   }
 
-  const redirectUrl = new URL("obsidian://petroglyph/oauth/callback");
+  const { callbackUri } = decodeState(state);
+  const redirectUrl = new URL(callbackUri ?? "obsidian://petroglyph/oauth/callback");
   redirectUrl.searchParams.set("code", code);
   redirectUrl.searchParams.set("state", state);
 
@@ -293,10 +307,11 @@ export async function handleOnedriveConnect(
   }
 
   const { code, state } = body;
+  const { stateHash } = decodeState(state);
   const userId = c.get("userId");
   console.info("[onedrive-connect] Starting connect flow", { userId });
 
-  const stateItem = await lookupStateItem(state);
+  const stateItem = await lookupStateItem(stateHash);
   const now = Math.floor(Date.now() / 1000);
 
   if (!stateItem || stateItem.type !== "onedrive_state" || stateItem.ttl < now) {
@@ -309,7 +324,7 @@ export async function handleOnedriveConnect(
     return c.json({ error: "Invalid or expired state" }, 401);
   }
 
-  await deleteStateItem(state);
+  await deleteStateItem(stateHash);
 
   let tokens: MicrosoftTokenResponse;
   try {


### PR DESCRIPTION
## Summary

Adds a standalone CLI harness to debug OneDrive OAuth flows locally, without requiring the full Obsidian plugin setup.

### Problem

OneDrive connection failures are hard to debug in the full Obsidian/plugin path. The Microsoft OAuth callback always redirected to `obsidian://`, making it impossible to intercept locally.

### Solution

**New harness script** (`packages/api/scripts/local-onedrive-flow.ts`):
- Runs a local HTTP server on port 8787 to capture OAuth callbacks
- Follows the exact same API endpoint sequence as the real plugin
- Persists credentials to `.working-docs/` (gitignored)
- Usage: `pnpm --filter @petroglyph/api local-onedrive-flow --api-base-url https://api.petroglyph.page`

**New API parameter** (`harnessCallbackUri` on `GET /onedrive/auth-url`):
- Accepts a localhost-only callback URI
- Encodes it into the PKCE state as `{uuid}|{base64url(uri)}`
- The bridge (`GET /onedrive/connect`) decodes state and redirects to the harness server instead of `obsidian://`
- `POST /onedrive/connect` strips the `|...` suffix before DynamoDB lookup (backwards compatible)

### Testing

- 189 tests pass (3 new harness tests)
- All gates green: lint ✓ typecheck ✓ build ✓ test ✓