### PR TITLE
[petroglyph-6xb] Fix status precedence — reconnect_required should override sync profile

### DIFF
--- a/packages/api/src/status.test.ts
+++ b/packages/api/src/status.test.ts
@@ -151,7 +151,7 @@ describe("GET /status", () => {
       expect(body.oneDriveStatus).toBe("reconnect_required");
     });
 
-    it("returns connected when reconnect_required is stale after a successful reconnect", async () => {
+    it("returns reconnect_required when user record has reconnect_required even if sync profile says connected", async () => {
       mockStatusReads({
         syncProfileItem: {
           userId: "user-42",
@@ -159,6 +159,30 @@ describe("GET /status", () => {
           oneDriveConnected: true,
         },
         userItem: { userId: "user-42", oneDriveStatus: "reconnect_required" },
+      });
+      const token = await makeValidToken();
+
+      const res = await app.request("/status", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        oneDrive: { connected: boolean };
+        oneDriveStatus: string;
+      };
+      expect(body.oneDrive.connected).toBe(false);
+      expect(body.oneDriveStatus).toBe("reconnect_required");
+    });
+
+    it("returns connected when sync profile says connected and user record has no reconnect_required", async () => {
+      mockStatusReads({
+        syncProfileItem: {
+          userId: "user-42",
+          profileId: "default",
+          oneDriveConnected: true,
+        },
+        userItem: { userId: "user-42" },
       });
       const token = await makeValidToken();
 

--- a/packages/api/src/status.ts
+++ b/packages/api/src/status.ts
@@ -98,11 +98,13 @@ export async function handleStatus(c: Context<{ Variables: AppVariables }>): Pro
     fetchSyncProfileStatus(userId),
     fetchStoredReconnectRequired(userId),
   ]);
-  const oneDriveStatus = syncProfileStatus.oneDriveConnected
-    ? "connected"
-    : storedReconnectRequired || syncProfileStatus.exists
-      ? "reconnect_required"
-      : "never_connected";
+  const oneDriveStatus = storedReconnectRequired
+    ? "reconnect_required"
+    : syncProfileStatus.oneDriveConnected
+      ? "connected"
+      : syncProfileStatus.exists
+        ? "reconnect_required"
+        : "never_connected";
 
   const body: StatusResponse = {
     github: { connected: true, username },


### PR DESCRIPTION
## Summary

Fixes a bug where the /status endpoint returned `connected` even when the user record had `reconnect_required` set, because sync profile `oneDriveConnected` was checked first.

## Changes

- **status.ts**: Reordered precedence so `fetchStoredReconnectRequired()` is checked first. If true, returns `reconnect_required` regardless of sync profile state.
- **status.test.ts**: Updated stale test to expect the corrected behavior, added a new test for the normal connected case.

## Testing

- All 190 API tests pass
- Lint: clean
- Security scan (gitleaks): no leaks found

Fixes petroglyph-6xb