### PR TITLE
[petroglyph-52o] Fix OneDrive connection UI not reflecting connected state after auth

### DIFF
--- a/packages/plugin/src/main.test.ts
+++ b/packages/plugin/src/main.test.ts
@@ -519,7 +519,7 @@ describe("handleOneDriveCallback", () => {
     vi.unstubAllGlobals();
   });
 
-  it("sets oneDriveConnected=true and saves data on success", async () => {
+  it("sets oneDriveConnected=true and oneDriveStatus=connected on success", async () => {
     const { plugin } = await makePlugin({ jwt: "jwt-token", refreshToken: "r", username: "alice" });
     const refreshSettingsUiSpy = vi.spyOn(plugin, "refreshSettingsUi").mockImplementation(() => {});
 
@@ -528,9 +528,10 @@ describe("handleOneDriveCallback", () => {
     await plugin.handleOneDriveCallback({ code: "abc", state: "xyz" });
 
     expect(plugin.data.oneDriveConnected).toBe(true);
+    expect(plugin.data.oneDriveStatus).toBe("connected");
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(plugin.saveData).toHaveBeenCalledWith(
-      expect.objectContaining({ oneDriveConnected: true }),
+      expect.objectContaining({ oneDriveConnected: true, oneDriveStatus: "connected" }),
     );
     expect(refreshSettingsUiSpy).toHaveBeenCalledOnce();
   });
@@ -649,6 +650,25 @@ describe("pollStatus", () => {
     await plugin.pollStatus();
 
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("reads oneDriveStatus from top-level response field", async () => {
+    const { plugin } = await makePlugin({
+      jwt: "jwt-token",
+      refreshToken: "r",
+      username: "alice",
+    });
+    const refreshSettingsUiSpy = vi.spyOn(plugin, "refreshSettingsUi").mockImplementation(() => {});
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ oneDriveStatus: "connected" }),
+    });
+
+    await plugin.pollStatus();
+
+    expect(plugin.data.oneDriveStatus).toBe("connected");
+    expect(refreshSettingsUiSpy).toHaveBeenCalledOnce();
   });
 
   it("silently ignores network errors", async () => {

--- a/packages/plugin/src/main.ts
+++ b/packages/plugin/src/main.ts
@@ -696,6 +696,7 @@ export class PetroglyphPlugin extends Plugin {
         return;
       }
       this.setOneDriveConnected(true);
+      this._data = { ...this._data, oneDriveStatus: "connected" };
       await this.savePluginData();
       this.refreshSettingsUi();
       this.startSyncPolling();
@@ -714,9 +715,9 @@ export class PetroglyphPlugin extends Plugin {
       if (!response.ok) return;
       const body: unknown = await response.json();
       if (!isRecord(body)) return;
+      let stateChanged = false;
       const oneDrive = body["oneDrive"];
       if (isRecord(oneDrive)) {
-        let stateChanged = false;
         if (typeof oneDrive["connected"] === "boolean") {
           if (this._data.oneDriveConnected !== oneDrive["connected"]) {
             this.setOneDriveConnected(oneDrive["connected"]);
@@ -729,12 +730,18 @@ export class PetroglyphPlugin extends Plugin {
             stateChanged = true;
           }
         }
-        if (!stateChanged) {
-          return;
-        }
-        await this.savePluginData();
-        this.refreshSettingsUi();
       }
+      if (typeof body["oneDriveStatus"] === "string") {
+        if (this._data.oneDriveStatus !== body["oneDriveStatus"]) {
+          this._data = { ...this._data, oneDriveStatus: body["oneDriveStatus"] };
+          stateChanged = true;
+        }
+      }
+      if (!stateChanged) {
+        return;
+      }
+      await this.savePluginData();
+      this.refreshSettingsUi();
     } catch {
       // Network errors are silently ignored; the next poll will retry.
     }


### PR DESCRIPTION
Fixes two bugs preventing the settings tab from showing 'OneDrive connected ✓' after successful OAuth:

**Bug 1**: handleOneDriveCallback was setting `oneDriveConnected=true` but not `oneDriveStatus='connected'`. Now both are set, so the UI immediately reflects the connected state.

**Bug 2**: pollStatus reads `oneDrive['status']` from the nested response field, but the API sends `oneDriveStatus` at the top level. Now both locations are checked.

## Verification
- ✅ 93/93 tests pass
- ✅ Typecheck clean
- ✅ Format clean
- ✅ gitleaks security scan clean