### PR TITLE
fix(files-changes): allow empty s3Key in file record schema

### DIFF
--- a/packages/api/src/files-changes.ts
+++ b/packages/api/src/files-changes.ts
@@ -119,6 +119,8 @@ async function readFileRecordPage(
 
   const parsed = queryResultSchema.safeParse(result);
   if (!parsed.success) {
+    console.error("Invalid file records response — Zod errors:", JSON.stringify(parsed.error.issues));
+    console.error("Raw result:", JSON.stringify(result));
     throw new Error("Invalid file records response");
   }
 

--- a/packages/api/src/files-changes.ts
+++ b/packages/api/src/files-changes.ts
@@ -28,7 +28,7 @@ const fileRecordSchema = z.object({
   fileId: z.string().min(1),
   filename: z.string().min(1),
   createdAt: z.string().min(1),
-  s3Key: z.string().min(1),
+  s3Key: z.string(),
   pageCount: z.number().int().positive().optional(),
 });
 

--- a/packages/api/src/files-changes.ts
+++ b/packages/api/src/files-changes.ts
@@ -119,7 +119,10 @@ async function readFileRecordPage(
 
   const parsed = queryResultSchema.safeParse(result);
   if (!parsed.success) {
-    console.error("Invalid file records response — Zod errors:", JSON.stringify(parsed.error.issues));
+    console.error(
+      "Invalid file records response — Zod errors:",
+      JSON.stringify(parsed.error.issues),
+    );
     console.error("Raw result:", JSON.stringify(result));
     throw new Error("Invalid file records response");
   }
@@ -190,8 +193,10 @@ export async function handleFilesChanges(c: Context): Promise<Response> {
 
   const { fileRecords, nextToken } = await readFileRecordPage(query.data.limit, exclusiveStartKey);
 
+  const stagedRecords = fileRecords.filter((r) => r.s3Key.length > 0);
+
   const files = await Promise.all(
-    fileRecords.map(async (fileRecord) => presignFileRecord(fileRecord)),
+    stagedRecords.map(async (fileRecord) => presignFileRecord(fileRecord)),
   );
 
   return c.json({ files, nextToken });


### PR DESCRIPTION
Pending file records have `s3Key: ""` before the processor downloads and stages the PDF. The `fileRecordSchema` used `z.string().min(1)` which rejected empty strings, causing Zod parse failure and throwing `"Invalid file records response"` — returning a 500 to the plugin.

Fix: change to `z.string()` to allow empty s3Key for unstaged files.