### PR TITLE
test(api): assert upsertSyncProfile sets all required sync-profile fields

### DIFF
--- a/packages/api/src/onedrive-connect.test.ts
+++ b/packages/api/src/onedrive-connect.test.ts
@@ -429,6 +429,19 @@ describe("POST /onedrive/connect", () => {
     expect(syncProfileCmd.input.ExpressionAttributeValues[":true"]).toBe(true);
     expect(typeof syncProfileCmd.input.ExpressionAttributeValues[":now"]).toBe("string");
 
+    // all required sync-profile fields set with sensible defaults
+    expect(syncProfileCmd.input.ExpressionAttributeValues[":name"]).toBe("default");
+    expect(syncProfileCmd.input.ExpressionAttributeValues[":rootPath"]).toBe("/");
+    expect(syncProfileCmd.input.ExpressionAttributeValues[":defaultDest"]).toBe("handwritten");
+    expect(syncProfileCmd.input.ExpressionAttributeValues[":interval"]).toBe(5);
+    expect(syncProfileCmd.input.UpdateExpression).toContain("#name");
+    expect(syncProfileCmd.input.UpdateExpression).toContain("sourceFolderPath");
+    expect(syncProfileCmd.input.UpdateExpression).toContain("destinationVaultPath");
+    expect(syncProfileCmd.input.UpdateExpression).toContain("#active");
+    expect(syncProfileCmd.input.UpdateExpression).toContain("initialSyncEnabled");
+    expect(syncProfileCmd.input.UpdateExpression).toContain("#enabled");
+    expect(syncProfileCmd.input.UpdateExpression).toContain("pollingIntervalMinutes");
+
     // markConnected
     const [userCmd] = updateCalls[2] as [
       {

--- a/packages/api/src/onedrive-connect.test.ts
+++ b/packages/api/src/onedrive-connect.test.ts
@@ -419,6 +419,7 @@ describe("POST /onedrive/connect", () => {
         input: {
           TableName: string;
           Key: { userId: string; profileId: string };
+          UpdateExpression: string;
           ExpressionAttributeValues: { [key: string]: unknown };
         };
       },


### PR DESCRIPTION
## Description
Adds test assertions verifying that upsertSyncProfile sets all required sync-profile fields with sensible defaults.

## Verification
- All 190 tests pass
- Lint clean
- syncProfileSchema validates correctly