### PR TITLE
feat(core): discriminated union file record schema with status-based s3Key validation

### DIFF
--- a/packages/api/src/files-changes.test.ts
+++ b/packages/api/src/files-changes.test.ts
@@ -145,6 +145,7 @@ describe("GET /files/changes", () => {
                 filename: "later.pdf",
                 createdAt: "2024-01-02T12:00:00.000Z",
                 s3Key: "staged/later.pdf",
+                status: "staged",
                 pageCount: 3,
               },
               {
@@ -153,6 +154,7 @@ describe("GET /files/changes", () => {
                 filename: "earlier.pdf",
                 createdAt: "2024-01-01T12:00:00.000Z",
                 s3Key: "staged/earlier.pdf",
+                status: "staged",
               },
             ],
           });
@@ -203,6 +205,7 @@ describe("GET /files/changes", () => {
               filename: "page-two.pdf",
               createdAt: "2024-01-03T12:00:00.000Z",
               s3Key: "staged/page-two.pdf",
+              status: "staged",
             },
           ],
           LastEvaluatedKey: {
@@ -273,6 +276,7 @@ describe("GET /files/changes", () => {
               filename: "final.pdf",
               createdAt: "2024-01-05T12:00:00.000Z",
               s3Key: "staged/final.pdf",
+              status: "staged",
             },
           ],
         });

--- a/packages/api/src/files-changes.ts
+++ b/packages/api/src/files-changes.ts
@@ -3,7 +3,8 @@ import { QueryCommand } from "@aws-sdk/lib-dynamodb";
 import type { Context } from "hono";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { z } from "zod";
-import { listProfiles } from "@petroglyph/core";
+import { listProfiles, fileRecordSchema } from "@petroglyph/core";
+import type { FileRecord, StagedFileRecord } from "@petroglyph/core";
 import { docClient } from "./db.js";
 
 const DEFAULT_PROFILE_ID = "default";
@@ -23,14 +24,7 @@ const cursorSchema = z.object({
   fileId: z.string().min(1),
 });
 
-const fileRecordSchema = z.object({
-  profileId: z.string().min(1),
-  fileId: z.string().min(1),
-  filename: z.string().min(1),
-  createdAt: z.string().min(1),
-  s3Key: z.string(),
-  pageCount: z.number().int().positive().optional(),
-});
+
 
 const queryResultSchema = z.object({
   Items: z.array(fileRecordSchema).optional(),
@@ -47,15 +41,6 @@ interface FileChange {
   filename: string;
   createdAt: string;
   pageCount?: number;
-}
-
-interface FileRecord {
-  profileId: string;
-  fileId: string;
-  filename: string;
-  createdAt: string;
-  s3Key: string;
-  pageCount?: number | undefined;
 }
 
 interface CursorToken {
@@ -145,7 +130,7 @@ async function readFileRecordPage(
   };
 }
 
-async function presignFileRecord(fileRecord: FileRecord): Promise<FileChange> {
+async function presignFileRecord(fileRecord: StagedFileRecord): Promise<FileChange> {
   const s3PresignedUrl = await getSignedUrl(
     s3Client,
     new GetObjectCommand({
@@ -193,7 +178,7 @@ export async function handleFilesChanges(c: Context): Promise<Response> {
 
   const { fileRecords, nextToken } = await readFileRecordPage(query.data.limit, exclusiveStartKey);
 
-  const stagedRecords = fileRecords.filter((r) => r.s3Key.length > 0);
+  const stagedRecords = fileRecords.filter((r): r is StagedFileRecord => r.status === "staged" && r.s3Key.length > 0);
 
   const files = await Promise.all(
     stagedRecords.map(async (fileRecord) => presignFileRecord(fileRecord)),

--- a/packages/api/src/files-changes.ts
+++ b/packages/api/src/files-changes.ts
@@ -24,8 +24,6 @@ const cursorSchema = z.object({
   fileId: z.string().min(1),
 });
 
-
-
 const queryResultSchema = z.object({
   Items: z.array(fileRecordSchema).optional(),
   LastEvaluatedKey: cursorSchema.optional(),
@@ -178,7 +176,9 @@ export async function handleFilesChanges(c: Context): Promise<Response> {
 
   const { fileRecords, nextToken } = await readFileRecordPage(query.data.limit, exclusiveStartKey);
 
-  const stagedRecords = fileRecords.filter((r): r is StagedFileRecord => r.status === "staged" && r.s3Key.length > 0);
+  const stagedRecords = fileRecords.filter(
+    (r): r is StagedFileRecord => r.status === "staged" && r.s3Key.length > 0,
+  );
 
   const files = await Promise.all(
     stagedRecords.map(async (fileRecord) => presignFileRecord(fileRecord)),

--- a/packages/api/src/openapi-types.ts
+++ b/packages/api/src/openapi-types.ts
@@ -4,1067 +4,1067 @@
  */
 
 export interface paths {
-  "/health": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Health check
+         * @description Returns 200 OK if service is running
+         */
+        get: operations["getHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Health check
-     * @description Returns 200 OK if service is running
-     */
-    get: operations["getHealth"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/url": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get GitHub OAuth authorization URL
+         * @description Returns a GitHub OAuth URL for the user to authorize the app
+         */
+        get: operations["getAuthUrl"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get GitHub OAuth authorization URL
-     * @description Returns a GitHub OAuth URL for the user to authorize the app
-     */
-    get: operations["getAuthUrl"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/callback": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Handle GitHub OAuth callback
+         * @description Exchange OAuth code for JWT and refresh token
+         */
+        post: operations["postAuthCallback"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Handle GitHub OAuth callback
-     * @description Exchange OAuth code for JWT and refresh token
-     */
-    post: operations["postAuthCallback"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/refresh": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh JWT access token
+         * @description Exchange a valid refresh token for a new JWT and refresh token
+         */
+        post: operations["postAuthRefresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Refresh JWT access token
-     * @description Exchange a valid refresh token for a new JWT and refresh token
-     */
-    post: operations["postAuthRefresh"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/status": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get connection status
+         * @description Returns GitHub and OneDrive connection status for authenticated user
+         */
+        get: operations["getStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get connection status
-     * @description Returns GitHub and OneDrive connection status for authenticated user
-     */
-    get: operations["getStatus"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/profiles": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/profiles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List sync profiles
+         * @description Returns all sync profiles for authenticated user
+         */
+        get: operations["listProfiles"];
+        put?: never;
+        /**
+         * Create sync profile
+         * @description Create a new sync profile for authenticated user
+         */
+        post: operations["createProfile"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List sync profiles
-     * @description Returns all sync profiles for authenticated user
-     */
-    get: operations["listProfiles"];
-    put?: never;
-    /**
-     * Create sync profile
-     * @description Create a new sync profile for authenticated user
-     */
-    post: operations["createProfile"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/profiles/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        id: string;
-      };
-      cookie?: never;
+    "/profiles/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Get sync profile
+         * @description Get a specific sync profile by ID
+         */
+        get: operations["getProfile"];
+        /**
+         * Update sync profile
+         * @description Update an existing sync profile
+         */
+        put: operations["updateProfile"];
+        post?: never;
+        /**
+         * Delete sync profile
+         * @description Delete a sync profile
+         */
+        delete: operations["deleteProfile"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get sync profile
-     * @description Get a specific sync profile by ID
-     */
-    get: operations["getProfile"];
-    /**
-     * Update sync profile
-     * @description Update an existing sync profile
-     */
-    put: operations["updateProfile"];
-    post?: never;
-    /**
-     * Delete sync profile
-     * @description Delete a sync profile
-     */
-    delete: operations["deleteProfile"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/files/changes": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/files/changes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get file changes
+         * @description Paginated list of file changes (new PDFs to sync)
+         */
+        get: operations["getFileChanges"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get file changes
-     * @description Paginated list of file changes (new PDFs to sync)
-     */
-    get: operations["getFileChanges"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/onedrive/auth-url": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/onedrive/auth-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get OneDrive OAuth authorization URL
+         * @description Returns a Microsoft OneDrive OAuth URL for the user
+         */
+        get: operations["getOneDriveAuthUrl"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get OneDrive OAuth authorization URL
-     * @description Returns a Microsoft OneDrive OAuth URL for the user
-     */
-    get: operations["getOneDriveAuthUrl"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/onedrive/connect": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/onedrive/connect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Handle Microsoft OAuth callback redirect
+         * @description Bridge endpoint that redirects Microsoft's OAuth callback to the Obsidian plugin URI handler. Preserves code and state query parameters.
+         */
+        get: operations["getOneDriveCallbackBridge"];
+        put?: never;
+        /**
+         * Complete OneDrive OAuth flow
+         * @description Exchange OneDrive OAuth code for access tokens
+         */
+        post: operations["postOneDriveConnect"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Handle Microsoft OAuth callback redirect
-     * @description Bridge endpoint that redirects Microsoft's OAuth callback to the Obsidian plugin URI handler. Preserves code and state query parameters.
-     */
-    get: operations["getOneDriveCallbackBridge"];
-    put?: never;
-    /**
-     * Complete OneDrive OAuth flow
-     * @description Exchange OneDrive OAuth code for access tokens
-     */
-    post: operations["postOneDriveConnect"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/onedrive/lifecycle": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/onedrive/lifecycle": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Handle OneDrive lifecycle notifications
+         * @description Microsoft Graph subscription lifecycle webhook endpoint
+         */
+        post: operations["postOneDriveLifecycle"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Handle OneDrive lifecycle notifications
-     * @description Microsoft Graph subscription lifecycle webhook endpoint
-     */
-    post: operations["postOneDriveLifecycle"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/sync/run": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/sync/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run manual sync
+         * @description Manually trigger a sync operation to check for new files
+         */
+        post: operations["postSyncRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Run manual sync
-     * @description Manually trigger a sync operation to check for new files
-     */
-    post: operations["postSyncRun"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/sync/reset": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/sync/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reset sync state
+         * @description Clear local sync state and restart from beginning
+         */
+        post: operations["postSyncReset"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Reset sync state
-     * @description Clear local sync state and restart from beginning
-     */
-    post: operations["postSyncReset"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    Error: {
-      error: string;
-      details?: Record<string, never>[];
+    schemas: {
+        Error: {
+            error: string;
+            details?: Record<string, never>[];
+        };
+        HealthResponse: {
+            /** @enum {string} */
+            status: "ok";
+        };
+        AuthUrlResponse: {
+            /**
+             * Format: uri
+             * @description GitHub OAuth authorization URL with state parameter
+             */
+            url: string;
+        };
+        AuthCallbackRequest: {
+            /** @description OAuth authorization code from GitHub */
+            code: string;
+            /** @description State token to prevent CSRF */
+            state: string;
+        };
+        AuthTokenResponse: {
+            /** @description Short-lived JWT access token (1 hour) */
+            jwt: string;
+            /** @description Long-lived refresh token (90 days) */
+            refreshToken: string;
+        };
+        AuthRefreshRequest: {
+            /** @description Valid refresh token */
+            refreshToken: string;
+        };
+        StatusResponse: {
+            github: {
+                connected: boolean;
+                username?: string;
+            };
+            oneDrive: {
+                connected: boolean;
+            };
+            /** @enum {string} */
+            oneDriveStatus: "connected" | "disconnected" | "never_connected" | "reconnect_required";
+        };
+        SyncProfile: {
+            /** Format: uuid */
+            profileId: string;
+            userId: string;
+            name: string;
+            /** @description OneDrive folder path to sync from */
+            sourceFolderPath: string;
+            /** @description Obsidian vault path to sync to */
+            destinationVaultPath: string;
+            /** @default 5 */
+            pollingIntervalMinutes: number;
+            /** @default true */
+            enabled: boolean;
+            /** @description Whether this is the currently active profile */
+            active: boolean;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        CreateProfileRequest: {
+            name: string;
+            sourceFolderPath: string;
+            destinationVaultPath: string;
+            pollingIntervalMinutes?: number;
+            enabled?: boolean;
+        };
+        UpdateProfileRequest: {
+            name?: string;
+            sourceFolderPath?: string;
+            destinationVaultPath?: string;
+            pollingIntervalMinutes?: number;
+            enabled?: boolean;
+            active?: boolean;
+        };
+        FileChange: {
+            fileId: string;
+            /**
+             * Format: uri
+             * @description Pre-signed S3 URL to download PDF (15 minute expiry)
+             */
+            s3PresignedUrl: string;
+            filename: string;
+            /** Format: date-time */
+            createdAt: string;
+            pageCount?: number;
+        };
+        FileChangesResponse: {
+            files: components["schemas"]["FileChange"][];
+            /** @description Cursor token for pagination (base64url encoded) */
+            nextToken?: string;
+            /** @description If true, client should clear local change token and refetch from start */
+            resetToken?: boolean;
+        };
+        OneDriveAuthUrlResponse: {
+            /**
+             * Format: uri
+             * @description Microsoft OneDrive OAuth authorization URL
+             */
+            url: string;
+        };
+        OneDriveConnectRequest: {
+            /** @description OAuth authorization code from Microsoft */
+            code: string;
+        };
+        OneDriveConnectResponse: {
+            success: boolean;
+        };
+        /** @description Microsoft Graph subscription lifecycle notification */
+        OneDriveLifecycleNotification: {
+            subscriptionId?: string;
+            /** Format: date-time */
+            subscriptionExpirationDateTime?: string;
+            changeType?: string;
+            resource?: string;
+            clientState?: string;
+        };
+        SyncRunResponse: {
+            /** @description Number of new files queued for processing */
+            queued: number;
+        };
+        SyncResetResponse: {
+            success: boolean;
+        };
     };
-    HealthResponse: {
-      /** @enum {string} */
-      status: "ok";
-    };
-    AuthUrlResponse: {
-      /**
-       * Format: uri
-       * @description GitHub OAuth authorization URL with state parameter
-       */
-      url: string;
-    };
-    AuthCallbackRequest: {
-      /** @description OAuth authorization code from GitHub */
-      code: string;
-      /** @description State token to prevent CSRF */
-      state: string;
-    };
-    AuthTokenResponse: {
-      /** @description Short-lived JWT access token (1 hour) */
-      jwt: string;
-      /** @description Long-lived refresh token (90 days) */
-      refreshToken: string;
-    };
-    AuthRefreshRequest: {
-      /** @description Valid refresh token */
-      refreshToken: string;
-    };
-    StatusResponse: {
-      github: {
-        connected: boolean;
-        username?: string;
-      };
-      oneDrive: {
-        connected: boolean;
-      };
-      /** @enum {string} */
-      oneDriveStatus: "connected" | "disconnected" | "never_connected" | "reconnect_required";
-    };
-    SyncProfile: {
-      /** Format: uuid */
-      profileId: string;
-      userId: string;
-      name: string;
-      /** @description OneDrive folder path to sync from */
-      sourceFolderPath: string;
-      /** @description Obsidian vault path to sync to */
-      destinationVaultPath: string;
-      /** @default 5 */
-      pollingIntervalMinutes: number;
-      /** @default true */
-      enabled: boolean;
-      /** @description Whether this is the currently active profile */
-      active: boolean;
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      updatedAt: string;
-    };
-    CreateProfileRequest: {
-      name: string;
-      sourceFolderPath: string;
-      destinationVaultPath: string;
-      pollingIntervalMinutes?: number;
-      enabled?: boolean;
-    };
-    UpdateProfileRequest: {
-      name?: string;
-      sourceFolderPath?: string;
-      destinationVaultPath?: string;
-      pollingIntervalMinutes?: number;
-      enabled?: boolean;
-      active?: boolean;
-    };
-    FileChange: {
-      fileId: string;
-      /**
-       * Format: uri
-       * @description Pre-signed S3 URL to download PDF (15 minute expiry)
-       */
-      s3PresignedUrl: string;
-      filename: string;
-      /** Format: date-time */
-      createdAt: string;
-      pageCount?: number;
-    };
-    FileChangesResponse: {
-      files: components["schemas"]["FileChange"][];
-      /** @description Cursor token for pagination (base64url encoded) */
-      nextToken?: string;
-      /** @description If true, client should clear local change token and refetch from start */
-      resetToken?: boolean;
-    };
-    OneDriveAuthUrlResponse: {
-      /**
-       * Format: uri
-       * @description Microsoft OneDrive OAuth authorization URL
-       */
-      url: string;
-    };
-    OneDriveConnectRequest: {
-      /** @description OAuth authorization code from Microsoft */
-      code: string;
-    };
-    OneDriveConnectResponse: {
-      success: boolean;
-    };
-    /** @description Microsoft Graph subscription lifecycle notification */
-    OneDriveLifecycleNotification: {
-      subscriptionId?: string;
-      /** Format: date-time */
-      subscriptionExpirationDateTime?: string;
-      changeType?: string;
-      resource?: string;
-      clientState?: string;
-    };
-    SyncRunResponse: {
-      /** @description Number of new files queued for processing */
-      queued: number;
-    };
-    SyncResetResponse: {
-      success: boolean;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  getHealth: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Service is healthy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Service is healthy */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getAuthUrl: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["HealthResponse"];
+        requestBody?: never;
+        responses: {
+            /** @description OAuth URL generated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthUrlResponse"];
+                };
+            };
+            /** @description Missing OAuth configuration */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-      };
     };
-  };
-  getAuthUrl: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    postAuthCallback: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthCallbackRequest"];
+            };
+        };
+        responses: {
+            /** @description Authentication successful */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthTokenResponse"];
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Invalid state or authorization code */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error during authentication */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description OAuth URL generated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    postAuthRefresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["AuthUrlResponse"];
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthRefreshRequest"];
+            };
         };
-      };
-      /** @description Missing OAuth configuration */
-      500: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Token refreshed successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthTokenResponse"];
+                };
+            };
+            /** @description Missing refresh token */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Invalid, expired, or reused refresh token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  postAuthCallback: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Status retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StatusResponse"];
+                };
+            };
+            /** @description Unauthorized - invalid or missing JWT */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthCallbackRequest"];
-      };
+    listProfiles: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Profiles retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncProfile"][];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Authentication successful */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    createProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["AuthTokenResponse"];
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateProfileRequest"];
+            };
         };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Profile created successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncProfile"];
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Invalid state or authorization code */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Server error during authentication */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  postAuthRefresh: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Profile retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncProfile"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Profile not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthRefreshRequest"];
-      };
+    updateProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateProfileRequest"];
+            };
+        };
+        responses: {
+            /** @description Profile updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncProfile"];
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Profile not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Token refreshed successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    deleteProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                id: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["AuthTokenResponse"];
+        requestBody?: never;
+        responses: {
+            /** @description Profile deleted successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Profile not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-      };
-      /** @description Missing refresh token */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Invalid, expired, or reused refresh token */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  getStatus: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getFileChanges: {
+        parameters: {
+            query?: {
+                /** @description Cursor token from previous response for pagination */
+                after?: string;
+                /** @description Maximum number of results per page */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description File changes retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FileChangesResponse"];
+                };
+            };
+            /** @description Invalid query parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Status retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getOneDriveAuthUrl: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["StatusResponse"];
+        requestBody?: never;
+        responses: {
+            /** @description OAuth URL generated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OneDriveAuthUrlResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Missing OAuth configuration */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-      };
-      /** @description Unauthorized - invalid or missing JWT */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  listProfiles: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getOneDriveCallbackBridge: {
+        parameters: {
+            query: {
+                /** @description Authorization code from Microsoft OAuth */
+                code: string;
+                /** @description State parameter for PKCE validation */
+                state: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirect to obsidian://petroglyph/oauth/callback with code and state parameters */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing required query parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Profiles retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    postOneDriveConnect: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["SyncProfile"][];
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OneDriveConnectRequest"];
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description OneDrive connected successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OneDriveConnectResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  createProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    postOneDriveLifecycle: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["OneDriveLifecycleNotification"];
+            };
+        };
+        responses: {
+            /** @description Notification processed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation token response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateProfileRequest"];
-      };
+    postSyncRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sync completed successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncRunResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Sync failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Profile created successfully */
-      201: {
-        headers: {
-          [name: string]: unknown;
+    postSyncReset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["SyncProfile"];
+        requestBody?: never;
+        responses: {
+            /** @description Sync reset successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncResetResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Reset failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  getProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Profile retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SyncProfile"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Profile not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  updateProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateProfileRequest"];
-      };
-    };
-    responses: {
-      /** @description Profile updated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SyncProfile"];
-        };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Profile not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  deleteProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Profile deleted successfully */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Profile not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  getFileChanges: {
-    parameters: {
-      query?: {
-        /** @description Cursor token from previous response for pagination */
-        after?: string;
-        /** @description Maximum number of results per page */
-        limit?: number;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description File changes retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["FileChangesResponse"];
-        };
-      };
-      /** @description Invalid query parameters */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  getOneDriveAuthUrl: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OAuth URL generated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["OneDriveAuthUrlResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Missing OAuth configuration */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  getOneDriveCallbackBridge: {
-    parameters: {
-      query: {
-        /** @description Authorization code from Microsoft OAuth */
-        code: string;
-        /** @description State parameter for PKCE validation */
-        state: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Redirect to obsidian://petroglyph/oauth/callback with code and state parameters */
-      302: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Missing required query parameters */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  postOneDriveConnect: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["OneDriveConnectRequest"];
-      };
-    };
-    responses: {
-      /** @description OneDrive connected successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["OneDriveConnectResponse"];
-        };
-      };
-      /** @description Invalid request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  postOneDriveLifecycle: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": components["schemas"]["OneDriveLifecycleNotification"];
-      };
-    };
-    responses: {
-      /** @description Notification processed */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation token response */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  postSyncRun: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Sync completed successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SyncRunResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Sync failed */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  postSyncReset: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Sync reset successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SyncResetResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Reset failed */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
 }

--- a/packages/api/src/openapi-types.ts
+++ b/packages/api/src/openapi-types.ts
@@ -4,1067 +4,1067 @@
  */
 
 export interface paths {
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health check
-         * @description Returns 200 OK if service is running
-         */
-        get: operations["getHealth"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/health": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/auth/url": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get GitHub OAuth authorization URL
-         * @description Returns a GitHub OAuth URL for the user to authorize the app
-         */
-        get: operations["getAuthUrl"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Health check
+     * @description Returns 200 OK if service is running
+     */
+    get: operations["getHealth"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/url": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/auth/callback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Handle GitHub OAuth callback
-         * @description Exchange OAuth code for JWT and refresh token
-         */
-        post: operations["postAuthCallback"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get GitHub OAuth authorization URL
+     * @description Returns a GitHub OAuth URL for the user to authorize the app
+     */
+    get: operations["getAuthUrl"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/callback": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/auth/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Refresh JWT access token
-         * @description Exchange a valid refresh token for a new JWT and refresh token
-         */
-        post: operations["postAuthRefresh"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Handle GitHub OAuth callback
+     * @description Exchange OAuth code for JWT and refresh token
+     */
+    post: operations["postAuthCallback"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/refresh": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get connection status
-         * @description Returns GitHub and OneDrive connection status for authenticated user
-         */
-        get: operations["getStatus"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Refresh JWT access token
+     * @description Exchange a valid refresh token for a new JWT and refresh token
+     */
+    post: operations["postAuthRefresh"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/status": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/profiles": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List sync profiles
-         * @description Returns all sync profiles for authenticated user
-         */
-        get: operations["listProfiles"];
-        put?: never;
-        /**
-         * Create sync profile
-         * @description Create a new sync profile for authenticated user
-         */
-        post: operations["createProfile"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get connection status
+     * @description Returns GitHub and OneDrive connection status for authenticated user
+     */
+    get: operations["getStatus"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/profiles": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/profiles/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        /**
-         * Get sync profile
-         * @description Get a specific sync profile by ID
-         */
-        get: operations["getProfile"];
-        /**
-         * Update sync profile
-         * @description Update an existing sync profile
-         */
-        put: operations["updateProfile"];
-        post?: never;
-        /**
-         * Delete sync profile
-         * @description Delete a sync profile
-         */
-        delete: operations["deleteProfile"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * List sync profiles
+     * @description Returns all sync profiles for authenticated user
+     */
+    get: operations["listProfiles"];
+    put?: never;
+    /**
+     * Create sync profile
+     * @description Create a new sync profile for authenticated user
+     */
+    post: operations["createProfile"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/profiles/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        id: string;
+      };
+      cookie?: never;
     };
-    "/files/changes": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get file changes
-         * @description Paginated list of file changes (new PDFs to sync)
-         */
-        get: operations["getFileChanges"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get sync profile
+     * @description Get a specific sync profile by ID
+     */
+    get: operations["getProfile"];
+    /**
+     * Update sync profile
+     * @description Update an existing sync profile
+     */
+    put: operations["updateProfile"];
+    post?: never;
+    /**
+     * Delete sync profile
+     * @description Delete a sync profile
+     */
+    delete: operations["deleteProfile"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/files/changes": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/onedrive/auth-url": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get OneDrive OAuth authorization URL
-         * @description Returns a Microsoft OneDrive OAuth URL for the user
-         */
-        get: operations["getOneDriveAuthUrl"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get file changes
+     * @description Paginated list of file changes (new PDFs to sync)
+     */
+    get: operations["getFileChanges"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/onedrive/auth-url": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/onedrive/connect": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Handle Microsoft OAuth callback redirect
-         * @description Bridge endpoint that redirects Microsoft's OAuth callback to the Obsidian plugin URI handler. Preserves code and state query parameters.
-         */
-        get: operations["getOneDriveCallbackBridge"];
-        put?: never;
-        /**
-         * Complete OneDrive OAuth flow
-         * @description Exchange OneDrive OAuth code for access tokens
-         */
-        post: operations["postOneDriveConnect"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get OneDrive OAuth authorization URL
+     * @description Returns a Microsoft OneDrive OAuth URL for the user
+     */
+    get: operations["getOneDriveAuthUrl"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/onedrive/connect": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/onedrive/lifecycle": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Handle OneDrive lifecycle notifications
-         * @description Microsoft Graph subscription lifecycle webhook endpoint
-         */
-        post: operations["postOneDriveLifecycle"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Handle Microsoft OAuth callback redirect
+     * @description Bridge endpoint that redirects Microsoft's OAuth callback to the Obsidian plugin URI handler. Preserves code and state query parameters.
+     */
+    get: operations["getOneDriveCallbackBridge"];
+    put?: never;
+    /**
+     * Complete OneDrive OAuth flow
+     * @description Exchange OneDrive OAuth code for access tokens
+     */
+    post: operations["postOneDriveConnect"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/onedrive/lifecycle": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/sync/run": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Run manual sync
-         * @description Manually trigger a sync operation to check for new files
-         */
-        post: operations["postSyncRun"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Handle OneDrive lifecycle notifications
+     * @description Microsoft Graph subscription lifecycle webhook endpoint
+     */
+    post: operations["postOneDriveLifecycle"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/sync/run": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/sync/reset": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reset sync state
-         * @description Clear local sync state and restart from beginning
-         */
-        post: operations["postSyncReset"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Run manual sync
+     * @description Manually trigger a sync operation to check for new files
+     */
+    post: operations["postSyncRun"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/sync/reset": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    get?: never;
+    put?: never;
+    /**
+     * Reset sync state
+     * @description Clear local sync state and restart from beginning
+     */
+    post: operations["postSyncReset"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        Error: {
-            error: string;
-            details?: Record<string, never>[];
-        };
-        HealthResponse: {
-            /** @enum {string} */
-            status: "ok";
-        };
-        AuthUrlResponse: {
-            /**
-             * Format: uri
-             * @description GitHub OAuth authorization URL with state parameter
-             */
-            url: string;
-        };
-        AuthCallbackRequest: {
-            /** @description OAuth authorization code from GitHub */
-            code: string;
-            /** @description State token to prevent CSRF */
-            state: string;
-        };
-        AuthTokenResponse: {
-            /** @description Short-lived JWT access token (1 hour) */
-            jwt: string;
-            /** @description Long-lived refresh token (90 days) */
-            refreshToken: string;
-        };
-        AuthRefreshRequest: {
-            /** @description Valid refresh token */
-            refreshToken: string;
-        };
-        StatusResponse: {
-            github: {
-                connected: boolean;
-                username?: string;
-            };
-            oneDrive: {
-                connected: boolean;
-            };
-            /** @enum {string} */
-            oneDriveStatus: "connected" | "disconnected" | "never_connected" | "reconnect_required";
-        };
-        SyncProfile: {
-            /** Format: uuid */
-            profileId: string;
-            userId: string;
-            name: string;
-            /** @description OneDrive folder path to sync from */
-            sourceFolderPath: string;
-            /** @description Obsidian vault path to sync to */
-            destinationVaultPath: string;
-            /** @default 5 */
-            pollingIntervalMinutes: number;
-            /** @default true */
-            enabled: boolean;
-            /** @description Whether this is the currently active profile */
-            active: boolean;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-        };
-        CreateProfileRequest: {
-            name: string;
-            sourceFolderPath: string;
-            destinationVaultPath: string;
-            pollingIntervalMinutes?: number;
-            enabled?: boolean;
-        };
-        UpdateProfileRequest: {
-            name?: string;
-            sourceFolderPath?: string;
-            destinationVaultPath?: string;
-            pollingIntervalMinutes?: number;
-            enabled?: boolean;
-            active?: boolean;
-        };
-        FileChange: {
-            fileId: string;
-            /**
-             * Format: uri
-             * @description Pre-signed S3 URL to download PDF (15 minute expiry)
-             */
-            s3PresignedUrl: string;
-            filename: string;
-            /** Format: date-time */
-            createdAt: string;
-            pageCount?: number;
-        };
-        FileChangesResponse: {
-            files: components["schemas"]["FileChange"][];
-            /** @description Cursor token for pagination (base64url encoded) */
-            nextToken?: string;
-            /** @description If true, client should clear local change token and refetch from start */
-            resetToken?: boolean;
-        };
-        OneDriveAuthUrlResponse: {
-            /**
-             * Format: uri
-             * @description Microsoft OneDrive OAuth authorization URL
-             */
-            url: string;
-        };
-        OneDriveConnectRequest: {
-            /** @description OAuth authorization code from Microsoft */
-            code: string;
-        };
-        OneDriveConnectResponse: {
-            success: boolean;
-        };
-        /** @description Microsoft Graph subscription lifecycle notification */
-        OneDriveLifecycleNotification: {
-            subscriptionId?: string;
-            /** Format: date-time */
-            subscriptionExpirationDateTime?: string;
-            changeType?: string;
-            resource?: string;
-            clientState?: string;
-        };
-        SyncRunResponse: {
-            /** @description Number of new files queued for processing */
-            queued: number;
-        };
-        SyncResetResponse: {
-            success: boolean;
-        };
+  schemas: {
+    Error: {
+      error: string;
+      details?: Record<string, never>[];
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    HealthResponse: {
+      /** @enum {string} */
+      status: "ok";
+    };
+    AuthUrlResponse: {
+      /**
+       * Format: uri
+       * @description GitHub OAuth authorization URL with state parameter
+       */
+      url: string;
+    };
+    AuthCallbackRequest: {
+      /** @description OAuth authorization code from GitHub */
+      code: string;
+      /** @description State token to prevent CSRF */
+      state: string;
+    };
+    AuthTokenResponse: {
+      /** @description Short-lived JWT access token (1 hour) */
+      jwt: string;
+      /** @description Long-lived refresh token (90 days) */
+      refreshToken: string;
+    };
+    AuthRefreshRequest: {
+      /** @description Valid refresh token */
+      refreshToken: string;
+    };
+    StatusResponse: {
+      github: {
+        connected: boolean;
+        username?: string;
+      };
+      oneDrive: {
+        connected: boolean;
+      };
+      /** @enum {string} */
+      oneDriveStatus: "connected" | "disconnected" | "never_connected" | "reconnect_required";
+    };
+    SyncProfile: {
+      /** Format: uuid */
+      profileId: string;
+      userId: string;
+      name: string;
+      /** @description OneDrive folder path to sync from */
+      sourceFolderPath: string;
+      /** @description Obsidian vault path to sync to */
+      destinationVaultPath: string;
+      /** @default 5 */
+      pollingIntervalMinutes: number;
+      /** @default true */
+      enabled: boolean;
+      /** @description Whether this is the currently active profile */
+      active: boolean;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+    };
+    CreateProfileRequest: {
+      name: string;
+      sourceFolderPath: string;
+      destinationVaultPath: string;
+      pollingIntervalMinutes?: number;
+      enabled?: boolean;
+    };
+    UpdateProfileRequest: {
+      name?: string;
+      sourceFolderPath?: string;
+      destinationVaultPath?: string;
+      pollingIntervalMinutes?: number;
+      enabled?: boolean;
+      active?: boolean;
+    };
+    FileChange: {
+      fileId: string;
+      /**
+       * Format: uri
+       * @description Pre-signed S3 URL to download PDF (15 minute expiry)
+       */
+      s3PresignedUrl: string;
+      filename: string;
+      /** Format: date-time */
+      createdAt: string;
+      pageCount?: number;
+    };
+    FileChangesResponse: {
+      files: components["schemas"]["FileChange"][];
+      /** @description Cursor token for pagination (base64url encoded) */
+      nextToken?: string;
+      /** @description If true, client should clear local change token and refetch from start */
+      resetToken?: boolean;
+    };
+    OneDriveAuthUrlResponse: {
+      /**
+       * Format: uri
+       * @description Microsoft OneDrive OAuth authorization URL
+       */
+      url: string;
+    };
+    OneDriveConnectRequest: {
+      /** @description OAuth authorization code from Microsoft */
+      code: string;
+    };
+    OneDriveConnectResponse: {
+      success: boolean;
+    };
+    /** @description Microsoft Graph subscription lifecycle notification */
+    OneDriveLifecycleNotification: {
+      subscriptionId?: string;
+      /** Format: date-time */
+      subscriptionExpirationDateTime?: string;
+      changeType?: string;
+      resource?: string;
+      clientState?: string;
+    };
+    SyncRunResponse: {
+      /** @description Number of new files queued for processing */
+      queued: number;
+    };
+    SyncResetResponse: {
+      success: boolean;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    getHealth: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Service is healthy */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HealthResponse"];
-                };
-            };
-        };
+  getHealth: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getAuthUrl: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Service is healthy */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OAuth URL generated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthUrlResponse"];
-                };
-            };
-            /** @description Missing OAuth configuration */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["HealthResponse"];
         };
+      };
     };
-    postAuthCallback: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthCallbackRequest"];
-            };
-        };
-        responses: {
-            /** @description Authentication successful */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthTokenResponse"];
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Invalid state or authorization code */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Server error during authentication */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+  };
+  getAuthUrl: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    postAuthRefresh: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OAuth URL generated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthRefreshRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthUrlResponse"];
         };
-        responses: {
-            /** @description Token refreshed successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthTokenResponse"];
-                };
-            };
-            /** @description Missing refresh token */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Invalid, expired, or reused refresh token */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+      };
+      /** @description Missing OAuth configuration */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
-    getStatus: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Status retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StatusResponse"];
-                };
-            };
-            /** @description Unauthorized - invalid or missing JWT */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+  };
+  postAuthCallback: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    listProfiles: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Profiles retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncProfile"][];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthCallbackRequest"];
+      };
     };
-    createProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Authentication successful */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateProfileRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthTokenResponse"];
         };
-        responses: {
-            /** @description Profile created successfully */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncProfile"];
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Invalid state or authorization code */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Server error during authentication */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
-    getProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Profile retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncProfile"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Profile not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+  };
+  postAuthRefresh: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    updateProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateProfileRequest"];
-            };
-        };
-        responses: {
-            /** @description Profile updated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncProfile"];
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Profile not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthRefreshRequest"];
+      };
     };
-    deleteProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                id: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Token refreshed successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Profile deleted successfully */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Profile not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["AuthTokenResponse"];
         };
+      };
+      /** @description Missing refresh token */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Invalid, expired, or reused refresh token */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
-    getFileChanges: {
-        parameters: {
-            query?: {
-                /** @description Cursor token from previous response for pagination */
-                after?: string;
-                /** @description Maximum number of results per page */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description File changes retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FileChangesResponse"];
-                };
-            };
-            /** @description Invalid query parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+  };
+  getStatus: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getOneDriveAuthUrl: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Status retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OAuth URL generated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OneDriveAuthUrlResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Missing OAuth configuration */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["StatusResponse"];
         };
+      };
+      /** @description Unauthorized - invalid or missing JWT */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
-    getOneDriveCallbackBridge: {
-        parameters: {
-            query: {
-                /** @description Authorization code from Microsoft OAuth */
-                code: string;
-                /** @description State parameter for PKCE validation */
-                state: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Redirect to obsidian://petroglyph/oauth/callback with code and state parameters */
-            302: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Missing required query parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+  };
+  listProfiles: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    postOneDriveConnect: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Profiles retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["OneDriveConnectRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["SyncProfile"][];
         };
-        responses: {
-            /** @description OneDrive connected successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OneDriveConnectResponse"];
-                };
-            };
-            /** @description Invalid request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
-    postOneDriveLifecycle: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["OneDriveLifecycleNotification"];
-            };
-        };
-        responses: {
-            /** @description Notification processed */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation token response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  createProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    postSyncRun: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Sync completed successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncRunResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Sync failed */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateProfileRequest"];
+      };
     };
-    postSyncReset: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Profile created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Sync reset successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncResetResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Reset failed */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["SyncProfile"];
         };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
+  };
+  getProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Profile retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SyncProfile"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Profile not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  updateProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateProfileRequest"];
+      };
+    };
+    responses: {
+      /** @description Profile updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SyncProfile"];
+        };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Profile not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  deleteProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Profile deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Profile not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  getFileChanges: {
+    parameters: {
+      query?: {
+        /** @description Cursor token from previous response for pagination */
+        after?: string;
+        /** @description Maximum number of results per page */
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description File changes retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["FileChangesResponse"];
+        };
+      };
+      /** @description Invalid query parameters */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  getOneDriveAuthUrl: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OAuth URL generated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["OneDriveAuthUrlResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Missing OAuth configuration */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  getOneDriveCallbackBridge: {
+    parameters: {
+      query: {
+        /** @description Authorization code from Microsoft OAuth */
+        code: string;
+        /** @description State parameter for PKCE validation */
+        state: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Redirect to obsidian://petroglyph/oauth/callback with code and state parameters */
+      302: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Missing required query parameters */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  postOneDriveConnect: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["OneDriveConnectRequest"];
+      };
+    };
+    responses: {
+      /** @description OneDrive connected successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["OneDriveConnectResponse"];
+        };
+      };
+      /** @description Invalid request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  postOneDriveLifecycle: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["OneDriveLifecycleNotification"];
+      };
+    };
+    responses: {
+      /** @description Notification processed */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation token response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  postSyncRun: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Sync completed successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SyncRunResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Sync failed */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  postSyncReset: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Sync reset successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SyncResetResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Reset failed */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
 }

--- a/packages/api/src/profiles-crud.test.ts
+++ b/packages/api/src/profiles-crud.test.ts
@@ -9,12 +9,16 @@ const mockPutProfile = vi.hoisted(() => vi.fn());
 const mockDeleteProfile = vi.hoisted(() => vi.fn());
 const mockDbSend = vi.hoisted(() => vi.fn());
 
-vi.mock("@petroglyph/core", () => ({
-  getProfile: mockGetProfile,
-  listProfiles: mockListProfiles,
-  putProfile: mockPutProfile,
-  deleteProfile: mockDeleteProfile,
-}));
+vi.mock("@petroglyph/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@petroglyph/core")>();
+  return {
+    ...actual,
+    getProfile: mockGetProfile,
+    listProfiles: mockListProfiles,
+    putProfile: mockPutProfile,
+    deleteProfile: mockDeleteProfile,
+  };
+});
 
 vi.mock("./db.js", () => ({
   docClient: { send: mockDbSend },

--- a/packages/api/src/profiles-crud.test.ts
+++ b/packages/api/src/profiles-crud.test.ts
@@ -10,6 +10,7 @@ const mockDeleteProfile = vi.hoisted(() => vi.fn());
 const mockDbSend = vi.hoisted(() => vi.fn());
 
 vi.mock("@petroglyph/core", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await importOriginal<typeof import("@petroglyph/core")>();
   return {
     ...actual,
@@ -18,7 +19,7 @@ vi.mock("@petroglyph/core", async (importOriginal) => {
     putProfile: mockPutProfile,
     deleteProfile: mockDeleteProfile,
   };
-});
+})
 
 vi.mock("./db.js", () => ({
   docClient: { send: mockDbSend },

--- a/packages/api/src/profiles-crud.test.ts
+++ b/packages/api/src/profiles-crud.test.ts
@@ -19,7 +19,7 @@ vi.mock("@petroglyph/core", async (importOriginal) => {
     putProfile: mockPutProfile,
     deleteProfile: mockDeleteProfile,
   };
-})
+});
 
 vi.mock("./db.js", () => ({
   docClient: { send: mockDbSend },

--- a/packages/api/src/profiles.test.ts
+++ b/packages/api/src/profiles.test.ts
@@ -6,6 +6,7 @@ const mockListProfiles = vi.hoisted(() => vi.fn<() => Promise<SyncProfile[]>>())
 const mockPutProfile = vi.hoisted(() => vi.fn<() => Promise<void>>());
 
 vi.mock("@petroglyph/core", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await importOriginal<typeof import("@petroglyph/core")>();
   return {
     ...actual,

--- a/packages/api/src/profiles.test.ts
+++ b/packages/api/src/profiles.test.ts
@@ -5,10 +5,14 @@ import type { SyncProfile } from "@petroglyph/core";
 const mockListProfiles = vi.hoisted(() => vi.fn<() => Promise<SyncProfile[]>>());
 const mockPutProfile = vi.hoisted(() => vi.fn<() => Promise<void>>());
 
-vi.mock("@petroglyph/core", () => ({
-  listProfiles: mockListProfiles,
-  putProfile: mockPutProfile,
-}));
+vi.mock("@petroglyph/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@petroglyph/core")>();
+  return {
+    ...actual,
+    listProfiles: mockListProfiles,
+    putProfile: mockPutProfile,
+  };
+});
 
 vi.mock("./db.js", () => ({
   docClient: {},

--- a/packages/core/src/file-record.ts
+++ b/packages/core/src/file-record.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+export const fileRecordStatusEnum = z.enum(["pending", "staged"]);
+export type FileRecordStatus = z.infer<typeof fileRecordStatusEnum>;
+
+const pendingFileRecordSchema = z.object({
+  profileId: z.string().min(1),
+  fileId: z.string().min(1),
+  filename: z.string().min(1),
+  createdAt: z.string().min(1),
+  s3Key: z.literal(""),
+  status: z.literal("pending"),
+  pageCount: z.number().int().positive().optional(),
+});
+
+const stagedFileRecordSchema = z.object({
+  profileId: z.string().min(1),
+  fileId: z.string().min(1),
+  filename: z.string().min(1),
+  createdAt: z.string().min(1),
+  s3Key: z.string().min(1),
+  status: z.literal("staged"),
+  pageCount: z.number().int().positive().optional(),
+});
+
+export const fileRecordSchema = z.discriminatedUnion("status", [
+  pendingFileRecordSchema,
+  stagedFileRecordSchema,
+]);
+
+export type PendingFileRecord = z.infer<typeof pendingFileRecordSchema>;
+export type StagedFileRecord = z.infer<typeof stagedFileRecordSchema>;
+export type FileRecord = z.infer<typeof fileRecordSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,13 @@
 export { syncProfileSchema } from "./sync-profile.js";
 export type { SyncProfile } from "./sync-profile.js";
 export { getProfile, listProfiles, putProfile, deleteProfile } from "./sync-profile-db.js";
+export {
+  fileRecordSchema,
+  fileRecordStatusEnum,
+} from "./file-record.js";
+export type {
+  FileRecord,
+  FileRecordStatus,
+  PendingFileRecord,
+  StagedFileRecord,
+} from "./file-record.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,10 +1,7 @@
 export { syncProfileSchema } from "./sync-profile.js";
 export type { SyncProfile } from "./sync-profile.js";
 export { getProfile, listProfiles, putProfile, deleteProfile } from "./sync-profile-db.js";
-export {
-  fileRecordSchema,
-  fileRecordStatusEnum,
-} from "./file-record.js";
+export { fileRecordSchema, fileRecordStatusEnum } from "./file-record.js";
 export type {
   FileRecord,
   FileRecordStatus,

--- a/packages/processor/src/index.test.ts
+++ b/packages/processor/src/index.test.ts
@@ -102,7 +102,7 @@ describe("processor handler", () => {
     vi.unstubAllEnvs();
   });
 
-  it("downloads the PDF, uploads it to S3, and writes a pending file record", async () => {
+  it("downloads the PDF, uploads it to S3, and writes a staged file record", async () => {
     mockOneDriveParams("default", makeTokenRecord());
 
     mockFetch
@@ -195,7 +195,7 @@ describe("processor handler", () => {
       fileId: "file-123",
       filename: "notes.pdf",
       s3Key: "handwritten/OnyxBoox/Meeting Notes/notes.pdf",
-      status: "pending",
+      status: "staged",
     });
     expect(typeof putCommand.input.Item?.["createdAt"]).toBe("string");
   });

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -264,7 +264,7 @@ async function writeFileRecord(
         filename,
         s3Key,
         createdAt: new Date().toISOString(),
-        status: "pending",
+        status: "staged",
       },
     }),
   );


### PR DESCRIPTION
## Description
Replace flat fileRecordSchema with discriminated union keyed on status. Pending records allow empty s3Key; staged records require non-empty s3Key.

## Changes
- New fileRecordSchema in @petroglyph/core with two variants
- Processor sets status='staged' after S3 upload
- files-changes filters for staged records only

## Verification
- All 190 API tests pass
- 4 processor tests pass
- Lint clean