### PR TITLE
feat(api): push SQS messages in sync-run so processor stages PDFs

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1024.0",
     "@aws-sdk/client-s3": "^3.1024.0",
+    "@aws-sdk/client-sqs": "^3.1029.0",
     "@aws-sdk/client-ssm": "^3.1024.0",
     "@aws-sdk/lib-dynamodb": "^3.1024.0",
     "@aws-sdk/s3-request-presigner": "^3.1024.0",

--- a/packages/api/src/files-changes.test.ts
+++ b/packages/api/src/files-changes.test.ts
@@ -227,11 +227,12 @@ describe("GET /files/changes", () => {
                 filename: "page-two.pdf",
                 createdAt: "2024-01-03T12:00:00.000Z",
                 s3Key: "staged/page-two.pdf",
+                status: "staged",
               },
             ],
             LastEvaluatedKey: {
               profileId: "default",
-            fileId: "file-3",
+              fileId: "file-3",
               filename: "page-two.pdf",
               createdAt: "2024-01-03T12:00:00.000Z",
               s3Key: "staged/page-two.pdf",
@@ -263,7 +264,9 @@ describe("GET /files/changes", () => {
     const queryCalls = mockDbSend.mock.calls.filter(([command]) => command instanceof QueryCommand);
     // 1 profile query (listProfiles) + 1 file records query
     // The file records query is the second QueryCommand call
-    const fileRecordsCommand = queryCalls[1][0] as {
+    expect(queryCalls[1]).toBeDefined();
+    const fileRecordQuery = queryCalls[1];
+    const fileRecordsCommand = fileRecordQuery![0] as {
       input: { ExclusiveStartKey: { profileId: string; fileId: string } };
     };
     expect(fileRecordsCommand.input.ExclusiveStartKey).toEqual({
@@ -288,7 +291,7 @@ describe("GET /files/changes", () => {
         createdAt: "2024-01-03T12:00:00.000Z",
       },
     ]);
-    expect(body.nextToken).toBe(encodeCursor({ profileId: "default", fileId: "file-4" }));
+    expect(body.nextToken).toBe(encodeCursor({ profileId: "default", fileId: "file-3" }));
   });
 
   it("returns null nextToken on the last page", async () => {
@@ -324,6 +327,7 @@ describe("GET /files/changes", () => {
                 filename: "final.pdf",
                 createdAt: "2024-01-05T12:00:00.000Z",
                 s3Key: "staged/final.pdf",
+                status: "staged",
               },
             ],
           });

--- a/packages/api/src/files-changes.test.ts
+++ b/packages/api/src/files-changes.test.ts
@@ -197,22 +197,48 @@ describe("GET /files/changes", () => {
   it("uses the opaque cursor to continue from the next page", async () => {
     mockDbSend.mockImplementation((command: unknown) => {
       if (command instanceof QueryCommand) {
-        return Promise.resolve({
-          Items: [
-            {
+        // Profile query (listProfiles queries by userId)
+        if (command.input.KeyConditionExpression?.includes("userId")) {
+          return Promise.resolve({
+            Items: [
+              {
+                profileId: "default",
+                userId: "user-42",
+                name: "Test Profile",
+                sourceFolderPath: "/test",
+                destinationVaultPath: "vault",
+                pollingIntervalMinutes: 5,
+                enabled: true,
+                active: true,
+                initialSyncEnabled: true,
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }
+        // File records query
+        if (command.input.KeyConditionExpression?.includes("profileId")) {
+          return Promise.resolve({
+            Items: [
+              {
+                profileId: "default",
+                fileId: "file-3",
+                filename: "page-two.pdf",
+                createdAt: "2024-01-03T12:00:00.000Z",
+                s3Key: "staged/page-two.pdf",
+              },
+            ],
+            LastEvaluatedKey: {
               profileId: "default",
-              fileId: "file-3",
+            fileId: "file-3",
               filename: "page-two.pdf",
               createdAt: "2024-01-03T12:00:00.000Z",
               s3Key: "staged/page-two.pdf",
               status: "staged",
             },
-          ],
-          LastEvaluatedKey: {
-            profileId: "default",
-            fileId: "file-4",
-          },
-        });
+          });
+        }
       }
 
       return Promise.reject(new Error("Unexpected DB call"));
@@ -235,12 +261,12 @@ describe("GET /files/changes", () => {
     expect(response.status).toBe(200);
 
     const queryCalls = mockDbSend.mock.calls.filter(([command]) => command instanceof QueryCommand);
-    expect(queryCalls).toHaveLength(1);
-
-    const [command] = queryCalls[0] as [
-      { input: { ExclusiveStartKey: { profileId: string; fileId: string } } },
-    ];
-    expect(command.input.ExclusiveStartKey).toEqual({
+    // 1 profile query (listProfiles) + 1 file records query
+    // The file records query is the second QueryCommand call
+    const fileRecordsCommand = queryCalls[1][0] as {
+      input: { ExclusiveStartKey: { profileId: string; fileId: string } };
+    };
+    expect(fileRecordsCommand.input.ExclusiveStartKey).toEqual({
       profileId: "default",
       fileId: "file-2",
     });
@@ -268,18 +294,40 @@ describe("GET /files/changes", () => {
   it("returns null nextToken on the last page", async () => {
     mockDbSend.mockImplementation((command: unknown) => {
       if (command instanceof QueryCommand) {
-        return Promise.resolve({
-          Items: [
-            {
-              profileId: "default",
-              fileId: "file-5",
-              filename: "final.pdf",
-              createdAt: "2024-01-05T12:00:00.000Z",
-              s3Key: "staged/final.pdf",
-              status: "staged",
-            },
-          ],
-        });
+        // Profile query (listProfiles queries by userId)
+        if (command.input.KeyConditionExpression?.includes("userId")) {
+          return Promise.resolve({
+            Items: [
+              {
+                profileId: "default",
+                userId: "user-42",
+                name: "Test Profile",
+                sourceFolderPath: "/test",
+                destinationVaultPath: "vault",
+                pollingIntervalMinutes: 5,
+                enabled: true,
+                active: true,
+                initialSyncEnabled: true,
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }
+        // File records query
+        if (command.input.KeyConditionExpression?.includes("profileId")) {
+          return Promise.resolve({
+            Items: [
+              {
+                profileId: "default",
+                fileId: "file-5",
+                filename: "final.pdf",
+                createdAt: "2024-01-05T12:00:00.000Z",
+                s3Key: "staged/final.pdf",
+              },
+            ],
+          });
+        }
       }
 
       return Promise.reject(new Error("Unexpected DB call"));

--- a/packages/api/src/files-changes.test.ts
+++ b/packages/api/src/files-changes.test.ts
@@ -265,10 +265,10 @@ describe("GET /files/changes", () => {
     // 1 profile query (listProfiles) + 1 file records query
     // The file records query is the second QueryCommand call
     expect(queryCalls[1]).toBeDefined();
-    const fileRecordQuery = queryCalls[1];
-    const fileRecordsCommand = fileRecordQuery![0] as {
-      input: { ExclusiveStartKey: { profileId: string; fileId: string } };
-    };
+    const fileRecordQuery: unknown = queryCalls[1];
+    const fileRecordsCommand = (
+      fileRecordQuery as [{ input: { ExclusiveStartKey: { profileId: string; fileId: string } } }]
+    )[0];
     expect(fileRecordsCommand.input.ExclusiveStartKey).toEqual({
       profileId: "default",
       fileId: "file-2",

--- a/packages/api/src/files-changes.ts
+++ b/packages/api/src/files-changes.ts
@@ -7,7 +7,10 @@ import { listProfiles, fileRecordSchema } from "@petroglyph/core";
 import type { FileRecord, StagedFileRecord } from "@petroglyph/core";
 import { docClient } from "./db.js";
 
-const DEFAULT_PROFILE_ID = "default";
+function fileRecordsTableName(): string {
+  return process.env["FILE_RECORDS_TABLE"] ?? "petroglyph-file-records-default";
+}
+
 const MAX_PAGE_SIZE = 100;
 const DEFAULT_PAGE_SIZE = 25;
 const PRESIGNED_URL_EXPIRES_IN_SECONDS = 15 * 60;
@@ -46,10 +49,6 @@ interface CursorToken {
   fileId: string;
 }
 
-function fileRecordsTableName(): string {
-  return process.env["FILE_RECORDS_TABLE"] ?? "petroglyph-file-records-default";
-}
-
 function stagedBucketName(): string {
   const bucketName = process.env["STAGED_PDFS_BUCKET"];
   if (!bucketName) {
@@ -82,6 +81,7 @@ async function readInitialSyncEnabled(userId: string): Promise<boolean> {
 }
 
 async function readFileRecordPage(
+  profileId: string,
   limit: number,
   exclusiveStartKey?: CursorToken,
 ): Promise<{ fileRecords: FileRecord[]; nextToken: string | null }> {
@@ -90,7 +90,7 @@ async function readFileRecordPage(
       TableName: fileRecordsTableName(),
       KeyConditionExpression: "profileId = :profileId",
       ExpressionAttributeValues: {
-        ":profileId": DEFAULT_PROFILE_ID,
+        ":profileId": profileId,
       },
       Limit: limit,
       ScanIndexForward: true,
@@ -165,6 +165,12 @@ export async function handleFilesChanges(c: Context): Promise<Response> {
     }
   }
 
+  const profiles = await listProfiles(docClient, syncProfilesTableName(), userId);
+  const activeProfile = profiles.find((p) => p.active);
+  if (!activeProfile) {
+    return c.json({ error: "No active profile configured" }, 400);
+  }
+
   let exclusiveStartKey: CursorToken | undefined;
   if (query.data.after !== undefined) {
     try {
@@ -174,7 +180,11 @@ export async function handleFilesChanges(c: Context): Promise<Response> {
     }
   }
 
-  const { fileRecords, nextToken } = await readFileRecordPage(query.data.limit, exclusiveStartKey);
+  const { fileRecords, nextToken } = await readFileRecordPage(
+    activeProfile.profileId,
+    query.data.limit,
+    exclusiveStartKey,
+  );
 
   const stagedRecords = fileRecords.filter(
     (r): r is StagedFileRecord => r.status === "staged" && r.s3Key.length > 0,

--- a/packages/api/src/openapi-types.ts
+++ b/packages/api/src/openapi-types.ts
@@ -4,1067 +4,1067 @@
  */
 
 export interface paths {
-  "/health": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Health check
+         * @description Returns 200 OK if service is running
+         */
+        get: operations["getHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Health check
-     * @description Returns 200 OK if service is running
-     */
-    get: operations["getHealth"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/url": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get GitHub OAuth authorization URL
+         * @description Returns a GitHub OAuth URL for the user to authorize the app
+         */
+        get: operations["getAuthUrl"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get GitHub OAuth authorization URL
-     * @description Returns a GitHub OAuth URL for the user to authorize the app
-     */
-    get: operations["getAuthUrl"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/callback": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Handle GitHub OAuth callback
+         * @description Exchange OAuth code for JWT and refresh token
+         */
+        post: operations["postAuthCallback"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Handle GitHub OAuth callback
-     * @description Exchange OAuth code for JWT and refresh token
-     */
-    post: operations["postAuthCallback"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/refresh": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh JWT access token
+         * @description Exchange a valid refresh token for a new JWT and refresh token
+         */
+        post: operations["postAuthRefresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Refresh JWT access token
-     * @description Exchange a valid refresh token for a new JWT and refresh token
-     */
-    post: operations["postAuthRefresh"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/status": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get connection status
+         * @description Returns GitHub and OneDrive connection status for authenticated user
+         */
+        get: operations["getStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get connection status
-     * @description Returns GitHub and OneDrive connection status for authenticated user
-     */
-    get: operations["getStatus"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/profiles": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/profiles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List sync profiles
+         * @description Returns all sync profiles for authenticated user
+         */
+        get: operations["listProfiles"];
+        put?: never;
+        /**
+         * Create sync profile
+         * @description Create a new sync profile for authenticated user
+         */
+        post: operations["createProfile"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List sync profiles
-     * @description Returns all sync profiles for authenticated user
-     */
-    get: operations["listProfiles"];
-    put?: never;
-    /**
-     * Create sync profile
-     * @description Create a new sync profile for authenticated user
-     */
-    post: operations["createProfile"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/profiles/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        id: string;
-      };
-      cookie?: never;
+    "/profiles/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Get sync profile
+         * @description Get a specific sync profile by ID
+         */
+        get: operations["getProfile"];
+        /**
+         * Update sync profile
+         * @description Update an existing sync profile
+         */
+        put: operations["updateProfile"];
+        post?: never;
+        /**
+         * Delete sync profile
+         * @description Delete a sync profile
+         */
+        delete: operations["deleteProfile"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get sync profile
-     * @description Get a specific sync profile by ID
-     */
-    get: operations["getProfile"];
-    /**
-     * Update sync profile
-     * @description Update an existing sync profile
-     */
-    put: operations["updateProfile"];
-    post?: never;
-    /**
-     * Delete sync profile
-     * @description Delete a sync profile
-     */
-    delete: operations["deleteProfile"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/files/changes": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/files/changes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get file changes
+         * @description Paginated list of file changes (new PDFs to sync)
+         */
+        get: operations["getFileChanges"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get file changes
-     * @description Paginated list of file changes (new PDFs to sync)
-     */
-    get: operations["getFileChanges"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/onedrive/auth-url": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/onedrive/auth-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get OneDrive OAuth authorization URL
+         * @description Returns a Microsoft OneDrive OAuth URL for the user
+         */
+        get: operations["getOneDriveAuthUrl"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get OneDrive OAuth authorization URL
-     * @description Returns a Microsoft OneDrive OAuth URL for the user
-     */
-    get: operations["getOneDriveAuthUrl"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/onedrive/connect": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/onedrive/connect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Handle Microsoft OAuth callback redirect
+         * @description Bridge endpoint that redirects Microsoft's OAuth callback to the Obsidian plugin URI handler. Preserves code and state query parameters.
+         */
+        get: operations["getOneDriveCallbackBridge"];
+        put?: never;
+        /**
+         * Complete OneDrive OAuth flow
+         * @description Exchange OneDrive OAuth code for access tokens
+         */
+        post: operations["postOneDriveConnect"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Handle Microsoft OAuth callback redirect
-     * @description Bridge endpoint that redirects Microsoft's OAuth callback to the Obsidian plugin URI handler. Preserves code and state query parameters.
-     */
-    get: operations["getOneDriveCallbackBridge"];
-    put?: never;
-    /**
-     * Complete OneDrive OAuth flow
-     * @description Exchange OneDrive OAuth code for access tokens
-     */
-    post: operations["postOneDriveConnect"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/onedrive/lifecycle": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/onedrive/lifecycle": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Handle OneDrive lifecycle notifications
+         * @description Microsoft Graph subscription lifecycle webhook endpoint
+         */
+        post: operations["postOneDriveLifecycle"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Handle OneDrive lifecycle notifications
-     * @description Microsoft Graph subscription lifecycle webhook endpoint
-     */
-    post: operations["postOneDriveLifecycle"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/sync/run": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/sync/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run manual sync
+         * @description Manually trigger a sync operation to check for new files
+         */
+        post: operations["postSyncRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Run manual sync
-     * @description Manually trigger a sync operation to check for new files
-     */
-    post: operations["postSyncRun"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/sync/reset": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/sync/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reset sync state
+         * @description Clear local sync state and restart from beginning
+         */
+        post: operations["postSyncReset"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Reset sync state
-     * @description Clear local sync state and restart from beginning
-     */
-    post: operations["postSyncReset"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    Error: {
-      error: string;
-      details?: Record<string, never>[];
+    schemas: {
+        Error: {
+            error: string;
+            details?: Record<string, never>[];
+        };
+        HealthResponse: {
+            /** @enum {string} */
+            status: "ok";
+        };
+        AuthUrlResponse: {
+            /**
+             * Format: uri
+             * @description GitHub OAuth authorization URL with state parameter
+             */
+            url: string;
+        };
+        AuthCallbackRequest: {
+            /** @description OAuth authorization code from GitHub */
+            code: string;
+            /** @description State token to prevent CSRF */
+            state: string;
+        };
+        AuthTokenResponse: {
+            /** @description Short-lived JWT access token (1 hour) */
+            jwt: string;
+            /** @description Long-lived refresh token (90 days) */
+            refreshToken: string;
+        };
+        AuthRefreshRequest: {
+            /** @description Valid refresh token */
+            refreshToken: string;
+        };
+        StatusResponse: {
+            github: {
+                connected: boolean;
+                username?: string;
+            };
+            oneDrive: {
+                connected: boolean;
+            };
+            /** @enum {string} */
+            oneDriveStatus: "connected" | "disconnected" | "never_connected" | "reconnect_required";
+        };
+        SyncProfile: {
+            /** Format: uuid */
+            profileId: string;
+            userId: string;
+            name: string;
+            /** @description OneDrive folder path to sync from */
+            sourceFolderPath: string;
+            /** @description Obsidian vault path to sync to */
+            destinationVaultPath: string;
+            /** @default 5 */
+            pollingIntervalMinutes: number;
+            /** @default true */
+            enabled: boolean;
+            /** @description Whether this is the currently active profile */
+            active: boolean;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        CreateProfileRequest: {
+            name: string;
+            sourceFolderPath: string;
+            destinationVaultPath: string;
+            pollingIntervalMinutes?: number;
+            enabled?: boolean;
+        };
+        UpdateProfileRequest: {
+            name?: string;
+            sourceFolderPath?: string;
+            destinationVaultPath?: string;
+            pollingIntervalMinutes?: number;
+            enabled?: boolean;
+            active?: boolean;
+        };
+        FileChange: {
+            fileId: string;
+            /**
+             * Format: uri
+             * @description Pre-signed S3 URL to download PDF (15 minute expiry)
+             */
+            s3PresignedUrl: string;
+            filename: string;
+            /** Format: date-time */
+            createdAt: string;
+            pageCount?: number;
+        };
+        FileChangesResponse: {
+            files: components["schemas"]["FileChange"][];
+            /** @description Cursor token for pagination (base64url encoded) */
+            nextToken?: string;
+            /** @description If true, client should clear local change token and refetch from start */
+            resetToken?: boolean;
+        };
+        OneDriveAuthUrlResponse: {
+            /**
+             * Format: uri
+             * @description Microsoft OneDrive OAuth authorization URL
+             */
+            url: string;
+        };
+        OneDriveConnectRequest: {
+            /** @description OAuth authorization code from Microsoft */
+            code: string;
+        };
+        OneDriveConnectResponse: {
+            success: boolean;
+        };
+        /** @description Microsoft Graph subscription lifecycle notification */
+        OneDriveLifecycleNotification: {
+            subscriptionId?: string;
+            /** Format: date-time */
+            subscriptionExpirationDateTime?: string;
+            changeType?: string;
+            resource?: string;
+            clientState?: string;
+        };
+        SyncRunResponse: {
+            /** @description Number of new files queued for processing */
+            queued: number;
+        };
+        SyncResetResponse: {
+            success: boolean;
+        };
     };
-    HealthResponse: {
-      /** @enum {string} */
-      status: "ok";
-    };
-    AuthUrlResponse: {
-      /**
-       * Format: uri
-       * @description GitHub OAuth authorization URL with state parameter
-       */
-      url: string;
-    };
-    AuthCallbackRequest: {
-      /** @description OAuth authorization code from GitHub */
-      code: string;
-      /** @description State token to prevent CSRF */
-      state: string;
-    };
-    AuthTokenResponse: {
-      /** @description Short-lived JWT access token (1 hour) */
-      jwt: string;
-      /** @description Long-lived refresh token (90 days) */
-      refreshToken: string;
-    };
-    AuthRefreshRequest: {
-      /** @description Valid refresh token */
-      refreshToken: string;
-    };
-    StatusResponse: {
-      github: {
-        connected: boolean;
-        username?: string;
-      };
-      oneDrive: {
-        connected: boolean;
-      };
-      /** @enum {string} */
-      oneDriveStatus: "connected" | "disconnected" | "never_connected" | "reconnect_required";
-    };
-    SyncProfile: {
-      /** Format: uuid */
-      profileId: string;
-      userId: string;
-      name: string;
-      /** @description OneDrive folder path to sync from */
-      sourceFolderPath: string;
-      /** @description Obsidian vault path to sync to */
-      destinationVaultPath: string;
-      /** @default 5 */
-      pollingIntervalMinutes: number;
-      /** @default true */
-      enabled: boolean;
-      /** @description Whether this is the currently active profile */
-      active: boolean;
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      updatedAt: string;
-    };
-    CreateProfileRequest: {
-      name: string;
-      sourceFolderPath: string;
-      destinationVaultPath: string;
-      pollingIntervalMinutes?: number;
-      enabled?: boolean;
-    };
-    UpdateProfileRequest: {
-      name?: string;
-      sourceFolderPath?: string;
-      destinationVaultPath?: string;
-      pollingIntervalMinutes?: number;
-      enabled?: boolean;
-      active?: boolean;
-    };
-    FileChange: {
-      fileId: string;
-      /**
-       * Format: uri
-       * @description Pre-signed S3 URL to download PDF (15 minute expiry)
-       */
-      s3PresignedUrl: string;
-      filename: string;
-      /** Format: date-time */
-      createdAt: string;
-      pageCount?: number;
-    };
-    FileChangesResponse: {
-      files: components["schemas"]["FileChange"][];
-      /** @description Cursor token for pagination (base64url encoded) */
-      nextToken?: string;
-      /** @description If true, client should clear local change token and refetch from start */
-      resetToken?: boolean;
-    };
-    OneDriveAuthUrlResponse: {
-      /**
-       * Format: uri
-       * @description Microsoft OneDrive OAuth authorization URL
-       */
-      url: string;
-    };
-    OneDriveConnectRequest: {
-      /** @description OAuth authorization code from Microsoft */
-      code: string;
-    };
-    OneDriveConnectResponse: {
-      success: boolean;
-    };
-    /** @description Microsoft Graph subscription lifecycle notification */
-    OneDriveLifecycleNotification: {
-      subscriptionId?: string;
-      /** Format: date-time */
-      subscriptionExpirationDateTime?: string;
-      changeType?: string;
-      resource?: string;
-      clientState?: string;
-    };
-    SyncRunResponse: {
-      /** @description Number of new files queued for processing */
-      queued: number;
-    };
-    SyncResetResponse: {
-      success: boolean;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  getHealth: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Service is healthy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Service is healthy */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getAuthUrl: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["HealthResponse"];
+        requestBody?: never;
+        responses: {
+            /** @description OAuth URL generated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthUrlResponse"];
+                };
+            };
+            /** @description Missing OAuth configuration */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-      };
     };
-  };
-  getAuthUrl: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    postAuthCallback: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthCallbackRequest"];
+            };
+        };
+        responses: {
+            /** @description Authentication successful */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthTokenResponse"];
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Invalid state or authorization code */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error during authentication */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description OAuth URL generated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    postAuthRefresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["AuthUrlResponse"];
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthRefreshRequest"];
+            };
         };
-      };
-      /** @description Missing OAuth configuration */
-      500: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Token refreshed successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthTokenResponse"];
+                };
+            };
+            /** @description Missing refresh token */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Invalid, expired, or reused refresh token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  postAuthCallback: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Status retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StatusResponse"];
+                };
+            };
+            /** @description Unauthorized - invalid or missing JWT */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthCallbackRequest"];
-      };
+    listProfiles: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Profiles retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncProfile"][];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Authentication successful */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    createProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["AuthTokenResponse"];
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateProfileRequest"];
+            };
         };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Profile created successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncProfile"];
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Invalid state or authorization code */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Server error during authentication */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  postAuthRefresh: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Profile retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncProfile"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Profile not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthRefreshRequest"];
-      };
+    updateProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateProfileRequest"];
+            };
+        };
+        responses: {
+            /** @description Profile updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncProfile"];
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Profile not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Token refreshed successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    deleteProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Profile ID */
+                id: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["AuthTokenResponse"];
+        requestBody?: never;
+        responses: {
+            /** @description Profile deleted successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Profile not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-      };
-      /** @description Missing refresh token */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Invalid, expired, or reused refresh token */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  getStatus: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getFileChanges: {
+        parameters: {
+            query?: {
+                /** @description Cursor token from previous response for pagination */
+                after?: string;
+                /** @description Maximum number of results per page */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description File changes retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FileChangesResponse"];
+                };
+            };
+            /** @description Invalid query parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Status retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getOneDriveAuthUrl: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["StatusResponse"];
+        requestBody?: never;
+        responses: {
+            /** @description OAuth URL generated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OneDriveAuthUrlResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Missing OAuth configuration */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-      };
-      /** @description Unauthorized - invalid or missing JWT */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  listProfiles: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getOneDriveCallbackBridge: {
+        parameters: {
+            query: {
+                /** @description Authorization code from Microsoft OAuth */
+                code: string;
+                /** @description State parameter for PKCE validation */
+                state: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirect to obsidian://petroglyph/oauth/callback with code and state parameters */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing required query parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Profiles retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    postOneDriveConnect: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["SyncProfile"][];
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OneDriveConnectRequest"];
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description OneDrive connected successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OneDriveConnectResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  createProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    postOneDriveLifecycle: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["OneDriveLifecycleNotification"];
+            };
+        };
+        responses: {
+            /** @description Notification processed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation token response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateProfileRequest"];
-      };
+    postSyncRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sync completed successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncRunResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Sync failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Profile created successfully */
-      201: {
-        headers: {
-          [name: string]: unknown;
+    postSyncReset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["SyncProfile"];
+        requestBody?: never;
+        responses: {
+            /** @description Sync reset successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncResetResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Reset failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
     };
-  };
-  getProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Profile retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SyncProfile"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Profile not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  updateProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateProfileRequest"];
-      };
-    };
-    responses: {
-      /** @description Profile updated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SyncProfile"];
-        };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Profile not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  deleteProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Profile ID */
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Profile deleted successfully */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Profile not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  getFileChanges: {
-    parameters: {
-      query?: {
-        /** @description Cursor token from previous response for pagination */
-        after?: string;
-        /** @description Maximum number of results per page */
-        limit?: number;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description File changes retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["FileChangesResponse"];
-        };
-      };
-      /** @description Invalid query parameters */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  getOneDriveAuthUrl: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OAuth URL generated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["OneDriveAuthUrlResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Missing OAuth configuration */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  getOneDriveCallbackBridge: {
-    parameters: {
-      query: {
-        /** @description Authorization code from Microsoft OAuth */
-        code: string;
-        /** @description State parameter for PKCE validation */
-        state: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Redirect to obsidian://petroglyph/oauth/callback with code and state parameters */
-      302: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Missing required query parameters */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  postOneDriveConnect: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["OneDriveConnectRequest"];
-      };
-    };
-    responses: {
-      /** @description OneDrive connected successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["OneDriveConnectResponse"];
-        };
-      };
-      /** @description Invalid request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  postOneDriveLifecycle: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": components["schemas"]["OneDriveLifecycleNotification"];
-      };
-    };
-    responses: {
-      /** @description Notification processed */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation token response */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  postSyncRun: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Sync completed successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SyncRunResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Sync failed */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  postSyncReset: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Sync reset successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SyncResetResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-      /** @description Reset failed */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
 }

--- a/packages/api/src/openapi-types.ts
+++ b/packages/api/src/openapi-types.ts
@@ -4,1067 +4,1067 @@
  */
 
 export interface paths {
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health check
-         * @description Returns 200 OK if service is running
-         */
-        get: operations["getHealth"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/health": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/auth/url": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get GitHub OAuth authorization URL
-         * @description Returns a GitHub OAuth URL for the user to authorize the app
-         */
-        get: operations["getAuthUrl"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Health check
+     * @description Returns 200 OK if service is running
+     */
+    get: operations["getHealth"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/url": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/auth/callback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Handle GitHub OAuth callback
-         * @description Exchange OAuth code for JWT and refresh token
-         */
-        post: operations["postAuthCallback"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get GitHub OAuth authorization URL
+     * @description Returns a GitHub OAuth URL for the user to authorize the app
+     */
+    get: operations["getAuthUrl"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/callback": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/auth/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Refresh JWT access token
-         * @description Exchange a valid refresh token for a new JWT and refresh token
-         */
-        post: operations["postAuthRefresh"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Handle GitHub OAuth callback
+     * @description Exchange OAuth code for JWT and refresh token
+     */
+    post: operations["postAuthCallback"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/refresh": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get connection status
-         * @description Returns GitHub and OneDrive connection status for authenticated user
-         */
-        get: operations["getStatus"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Refresh JWT access token
+     * @description Exchange a valid refresh token for a new JWT and refresh token
+     */
+    post: operations["postAuthRefresh"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/status": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/profiles": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List sync profiles
-         * @description Returns all sync profiles for authenticated user
-         */
-        get: operations["listProfiles"];
-        put?: never;
-        /**
-         * Create sync profile
-         * @description Create a new sync profile for authenticated user
-         */
-        post: operations["createProfile"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get connection status
+     * @description Returns GitHub and OneDrive connection status for authenticated user
+     */
+    get: operations["getStatus"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/profiles": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/profiles/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        /**
-         * Get sync profile
-         * @description Get a specific sync profile by ID
-         */
-        get: operations["getProfile"];
-        /**
-         * Update sync profile
-         * @description Update an existing sync profile
-         */
-        put: operations["updateProfile"];
-        post?: never;
-        /**
-         * Delete sync profile
-         * @description Delete a sync profile
-         */
-        delete: operations["deleteProfile"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * List sync profiles
+     * @description Returns all sync profiles for authenticated user
+     */
+    get: operations["listProfiles"];
+    put?: never;
+    /**
+     * Create sync profile
+     * @description Create a new sync profile for authenticated user
+     */
+    post: operations["createProfile"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/profiles/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        id: string;
+      };
+      cookie?: never;
     };
-    "/files/changes": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get file changes
-         * @description Paginated list of file changes (new PDFs to sync)
-         */
-        get: operations["getFileChanges"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get sync profile
+     * @description Get a specific sync profile by ID
+     */
+    get: operations["getProfile"];
+    /**
+     * Update sync profile
+     * @description Update an existing sync profile
+     */
+    put: operations["updateProfile"];
+    post?: never;
+    /**
+     * Delete sync profile
+     * @description Delete a sync profile
+     */
+    delete: operations["deleteProfile"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/files/changes": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/onedrive/auth-url": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get OneDrive OAuth authorization URL
-         * @description Returns a Microsoft OneDrive OAuth URL for the user
-         */
-        get: operations["getOneDriveAuthUrl"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get file changes
+     * @description Paginated list of file changes (new PDFs to sync)
+     */
+    get: operations["getFileChanges"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/onedrive/auth-url": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/onedrive/connect": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Handle Microsoft OAuth callback redirect
-         * @description Bridge endpoint that redirects Microsoft's OAuth callback to the Obsidian plugin URI handler. Preserves code and state query parameters.
-         */
-        get: operations["getOneDriveCallbackBridge"];
-        put?: never;
-        /**
-         * Complete OneDrive OAuth flow
-         * @description Exchange OneDrive OAuth code for access tokens
-         */
-        post: operations["postOneDriveConnect"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get OneDrive OAuth authorization URL
+     * @description Returns a Microsoft OneDrive OAuth URL for the user
+     */
+    get: operations["getOneDriveAuthUrl"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/onedrive/connect": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/onedrive/lifecycle": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Handle OneDrive lifecycle notifications
-         * @description Microsoft Graph subscription lifecycle webhook endpoint
-         */
-        post: operations["postOneDriveLifecycle"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Handle Microsoft OAuth callback redirect
+     * @description Bridge endpoint that redirects Microsoft's OAuth callback to the Obsidian plugin URI handler. Preserves code and state query parameters.
+     */
+    get: operations["getOneDriveCallbackBridge"];
+    put?: never;
+    /**
+     * Complete OneDrive OAuth flow
+     * @description Exchange OneDrive OAuth code for access tokens
+     */
+    post: operations["postOneDriveConnect"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/onedrive/lifecycle": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/sync/run": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Run manual sync
-         * @description Manually trigger a sync operation to check for new files
-         */
-        post: operations["postSyncRun"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Handle OneDrive lifecycle notifications
+     * @description Microsoft Graph subscription lifecycle webhook endpoint
+     */
+    post: operations["postOneDriveLifecycle"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/sync/run": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/sync/reset": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reset sync state
-         * @description Clear local sync state and restart from beginning
-         */
-        post: operations["postSyncReset"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Run manual sync
+     * @description Manually trigger a sync operation to check for new files
+     */
+    post: operations["postSyncRun"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/sync/reset": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    get?: never;
+    put?: never;
+    /**
+     * Reset sync state
+     * @description Clear local sync state and restart from beginning
+     */
+    post: operations["postSyncReset"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        Error: {
-            error: string;
-            details?: Record<string, never>[];
-        };
-        HealthResponse: {
-            /** @enum {string} */
-            status: "ok";
-        };
-        AuthUrlResponse: {
-            /**
-             * Format: uri
-             * @description GitHub OAuth authorization URL with state parameter
-             */
-            url: string;
-        };
-        AuthCallbackRequest: {
-            /** @description OAuth authorization code from GitHub */
-            code: string;
-            /** @description State token to prevent CSRF */
-            state: string;
-        };
-        AuthTokenResponse: {
-            /** @description Short-lived JWT access token (1 hour) */
-            jwt: string;
-            /** @description Long-lived refresh token (90 days) */
-            refreshToken: string;
-        };
-        AuthRefreshRequest: {
-            /** @description Valid refresh token */
-            refreshToken: string;
-        };
-        StatusResponse: {
-            github: {
-                connected: boolean;
-                username?: string;
-            };
-            oneDrive: {
-                connected: boolean;
-            };
-            /** @enum {string} */
-            oneDriveStatus: "connected" | "disconnected" | "never_connected" | "reconnect_required";
-        };
-        SyncProfile: {
-            /** Format: uuid */
-            profileId: string;
-            userId: string;
-            name: string;
-            /** @description OneDrive folder path to sync from */
-            sourceFolderPath: string;
-            /** @description Obsidian vault path to sync to */
-            destinationVaultPath: string;
-            /** @default 5 */
-            pollingIntervalMinutes: number;
-            /** @default true */
-            enabled: boolean;
-            /** @description Whether this is the currently active profile */
-            active: boolean;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-        };
-        CreateProfileRequest: {
-            name: string;
-            sourceFolderPath: string;
-            destinationVaultPath: string;
-            pollingIntervalMinutes?: number;
-            enabled?: boolean;
-        };
-        UpdateProfileRequest: {
-            name?: string;
-            sourceFolderPath?: string;
-            destinationVaultPath?: string;
-            pollingIntervalMinutes?: number;
-            enabled?: boolean;
-            active?: boolean;
-        };
-        FileChange: {
-            fileId: string;
-            /**
-             * Format: uri
-             * @description Pre-signed S3 URL to download PDF (15 minute expiry)
-             */
-            s3PresignedUrl: string;
-            filename: string;
-            /** Format: date-time */
-            createdAt: string;
-            pageCount?: number;
-        };
-        FileChangesResponse: {
-            files: components["schemas"]["FileChange"][];
-            /** @description Cursor token for pagination (base64url encoded) */
-            nextToken?: string;
-            /** @description If true, client should clear local change token and refetch from start */
-            resetToken?: boolean;
-        };
-        OneDriveAuthUrlResponse: {
-            /**
-             * Format: uri
-             * @description Microsoft OneDrive OAuth authorization URL
-             */
-            url: string;
-        };
-        OneDriveConnectRequest: {
-            /** @description OAuth authorization code from Microsoft */
-            code: string;
-        };
-        OneDriveConnectResponse: {
-            success: boolean;
-        };
-        /** @description Microsoft Graph subscription lifecycle notification */
-        OneDriveLifecycleNotification: {
-            subscriptionId?: string;
-            /** Format: date-time */
-            subscriptionExpirationDateTime?: string;
-            changeType?: string;
-            resource?: string;
-            clientState?: string;
-        };
-        SyncRunResponse: {
-            /** @description Number of new files queued for processing */
-            queued: number;
-        };
-        SyncResetResponse: {
-            success: boolean;
-        };
+  schemas: {
+    Error: {
+      error: string;
+      details?: Record<string, never>[];
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    HealthResponse: {
+      /** @enum {string} */
+      status: "ok";
+    };
+    AuthUrlResponse: {
+      /**
+       * Format: uri
+       * @description GitHub OAuth authorization URL with state parameter
+       */
+      url: string;
+    };
+    AuthCallbackRequest: {
+      /** @description OAuth authorization code from GitHub */
+      code: string;
+      /** @description State token to prevent CSRF */
+      state: string;
+    };
+    AuthTokenResponse: {
+      /** @description Short-lived JWT access token (1 hour) */
+      jwt: string;
+      /** @description Long-lived refresh token (90 days) */
+      refreshToken: string;
+    };
+    AuthRefreshRequest: {
+      /** @description Valid refresh token */
+      refreshToken: string;
+    };
+    StatusResponse: {
+      github: {
+        connected: boolean;
+        username?: string;
+      };
+      oneDrive: {
+        connected: boolean;
+      };
+      /** @enum {string} */
+      oneDriveStatus: "connected" | "disconnected" | "never_connected" | "reconnect_required";
+    };
+    SyncProfile: {
+      /** Format: uuid */
+      profileId: string;
+      userId: string;
+      name: string;
+      /** @description OneDrive folder path to sync from */
+      sourceFolderPath: string;
+      /** @description Obsidian vault path to sync to */
+      destinationVaultPath: string;
+      /** @default 5 */
+      pollingIntervalMinutes: number;
+      /** @default true */
+      enabled: boolean;
+      /** @description Whether this is the currently active profile */
+      active: boolean;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+    };
+    CreateProfileRequest: {
+      name: string;
+      sourceFolderPath: string;
+      destinationVaultPath: string;
+      pollingIntervalMinutes?: number;
+      enabled?: boolean;
+    };
+    UpdateProfileRequest: {
+      name?: string;
+      sourceFolderPath?: string;
+      destinationVaultPath?: string;
+      pollingIntervalMinutes?: number;
+      enabled?: boolean;
+      active?: boolean;
+    };
+    FileChange: {
+      fileId: string;
+      /**
+       * Format: uri
+       * @description Pre-signed S3 URL to download PDF (15 minute expiry)
+       */
+      s3PresignedUrl: string;
+      filename: string;
+      /** Format: date-time */
+      createdAt: string;
+      pageCount?: number;
+    };
+    FileChangesResponse: {
+      files: components["schemas"]["FileChange"][];
+      /** @description Cursor token for pagination (base64url encoded) */
+      nextToken?: string;
+      /** @description If true, client should clear local change token and refetch from start */
+      resetToken?: boolean;
+    };
+    OneDriveAuthUrlResponse: {
+      /**
+       * Format: uri
+       * @description Microsoft OneDrive OAuth authorization URL
+       */
+      url: string;
+    };
+    OneDriveConnectRequest: {
+      /** @description OAuth authorization code from Microsoft */
+      code: string;
+    };
+    OneDriveConnectResponse: {
+      success: boolean;
+    };
+    /** @description Microsoft Graph subscription lifecycle notification */
+    OneDriveLifecycleNotification: {
+      subscriptionId?: string;
+      /** Format: date-time */
+      subscriptionExpirationDateTime?: string;
+      changeType?: string;
+      resource?: string;
+      clientState?: string;
+    };
+    SyncRunResponse: {
+      /** @description Number of new files queued for processing */
+      queued: number;
+    };
+    SyncResetResponse: {
+      success: boolean;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    getHealth: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Service is healthy */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HealthResponse"];
-                };
-            };
-        };
+  getHealth: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getAuthUrl: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Service is healthy */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OAuth URL generated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthUrlResponse"];
-                };
-            };
-            /** @description Missing OAuth configuration */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["HealthResponse"];
         };
+      };
     };
-    postAuthCallback: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthCallbackRequest"];
-            };
-        };
-        responses: {
-            /** @description Authentication successful */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthTokenResponse"];
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Invalid state or authorization code */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Server error during authentication */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+  };
+  getAuthUrl: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    postAuthRefresh: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OAuth URL generated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthRefreshRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthUrlResponse"];
         };
-        responses: {
-            /** @description Token refreshed successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthTokenResponse"];
-                };
-            };
-            /** @description Missing refresh token */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Invalid, expired, or reused refresh token */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+      };
+      /** @description Missing OAuth configuration */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
-    getStatus: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Status retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StatusResponse"];
-                };
-            };
-            /** @description Unauthorized - invalid or missing JWT */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+  };
+  postAuthCallback: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    listProfiles: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Profiles retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncProfile"][];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthCallbackRequest"];
+      };
     };
-    createProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Authentication successful */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateProfileRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthTokenResponse"];
         };
-        responses: {
-            /** @description Profile created successfully */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncProfile"];
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Invalid state or authorization code */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Server error during authentication */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
-    getProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Profile retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncProfile"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Profile not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+  };
+  postAuthRefresh: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    updateProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateProfileRequest"];
-            };
-        };
-        responses: {
-            /** @description Profile updated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncProfile"];
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Profile not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthRefreshRequest"];
+      };
     };
-    deleteProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Profile ID */
-                id: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Token refreshed successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Profile deleted successfully */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Profile not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["AuthTokenResponse"];
         };
+      };
+      /** @description Missing refresh token */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Invalid, expired, or reused refresh token */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
-    getFileChanges: {
-        parameters: {
-            query?: {
-                /** @description Cursor token from previous response for pagination */
-                after?: string;
-                /** @description Maximum number of results per page */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description File changes retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FileChangesResponse"];
-                };
-            };
-            /** @description Invalid query parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+  };
+  getStatus: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getOneDriveAuthUrl: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Status retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OAuth URL generated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OneDriveAuthUrlResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Missing OAuth configuration */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["StatusResponse"];
         };
+      };
+      /** @description Unauthorized - invalid or missing JWT */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
-    getOneDriveCallbackBridge: {
-        parameters: {
-            query: {
-                /** @description Authorization code from Microsoft OAuth */
-                code: string;
-                /** @description State parameter for PKCE validation */
-                state: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Redirect to obsidian://petroglyph/oauth/callback with code and state parameters */
-            302: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Missing required query parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+  };
+  listProfiles: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    postOneDriveConnect: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Profiles retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["OneDriveConnectRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["SyncProfile"][];
         };
-        responses: {
-            /** @description OneDrive connected successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OneDriveConnectResponse"];
-                };
-            };
-            /** @description Invalid request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
-    postOneDriveLifecycle: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["OneDriveLifecycleNotification"];
-            };
-        };
-        responses: {
-            /** @description Notification processed */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation token response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  createProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    postSyncRun: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Sync completed successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncRunResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Sync failed */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateProfileRequest"];
+      };
     };
-    postSyncReset: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Profile created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Sync reset successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncResetResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Reset failed */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["SyncProfile"];
         };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
     };
+  };
+  getProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Profile retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SyncProfile"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Profile not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  updateProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateProfileRequest"];
+      };
+    };
+    responses: {
+      /** @description Profile updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SyncProfile"];
+        };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Profile not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  deleteProfile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Profile ID */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Profile deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Profile not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  getFileChanges: {
+    parameters: {
+      query?: {
+        /** @description Cursor token from previous response for pagination */
+        after?: string;
+        /** @description Maximum number of results per page */
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description File changes retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["FileChangesResponse"];
+        };
+      };
+      /** @description Invalid query parameters */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  getOneDriveAuthUrl: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OAuth URL generated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["OneDriveAuthUrlResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Missing OAuth configuration */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  getOneDriveCallbackBridge: {
+    parameters: {
+      query: {
+        /** @description Authorization code from Microsoft OAuth */
+        code: string;
+        /** @description State parameter for PKCE validation */
+        state: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Redirect to obsidian://petroglyph/oauth/callback with code and state parameters */
+      302: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Missing required query parameters */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  postOneDriveConnect: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["OneDriveConnectRequest"];
+      };
+    };
+    responses: {
+      /** @description OneDrive connected successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["OneDriveConnectResponse"];
+        };
+      };
+      /** @description Invalid request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  postOneDriveLifecycle: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["OneDriveLifecycleNotification"];
+      };
+    };
+    responses: {
+      /** @description Notification processed */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation token response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  postSyncRun: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Sync completed successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SyncRunResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Sync failed */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  postSyncReset: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Sync reset successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SyncResetResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+      /** @description Reset failed */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
 }

--- a/packages/api/src/sync-run.test.ts
+++ b/packages/api/src/sync-run.test.ts
@@ -4,10 +4,23 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 
 const mockDbSend = vi.hoisted(() => vi.fn());
 const mockFetch = vi.hoisted(() => vi.fn());
+const mockSqsSend = vi.hoisted(() => vi.fn());
 
 vi.mock("./db.js", () => ({
   docClient: { send: mockDbSend },
 }));
+
+vi.mock("@aws-sdk/client-sqs", () => {
+  const mockSend = mockSqsSend;
+  return {
+    SQSClient: class {
+      send = mockSend;
+    },
+    SendMessageCommand: class {
+      constructor(public input: unknown) {}
+    },
+  };
+});
 
 vi.stubGlobal("fetch", mockFetch);
 
@@ -33,8 +46,13 @@ describe("POST /sync/run", () => {
     vi.stubEnv("DELTA_TOKENS_TABLE", "petroglyph-delta-tokens-test");
     vi.stubEnv("MICROSOFT_CLIENT_ID", "test-client-id");
     vi.stubEnv("MICROSOFT_CLIENT_SECRET", "test-client-secret");
+    vi.stubEnv(
+      "INGEST_QUEUE_URL",
+      "https://sqs.eu-west-2.amazonaws.com/123456789/petroglyph-ingest-test",
+    );
     mockDbSend.mockReset();
     mockFetch.mockReset();
+    mockSqsSend.mockReset();
     resetKeyCache();
   });
 
@@ -209,6 +227,28 @@ describe("POST /sync/run", () => {
     expect(deltaTokenCommand.input.TableName).toBe("petroglyph-delta-tokens-test");
     expect(deltaTokenCommand.input.Item.profileId).toBe("default");
     expect(deltaTokenCommand.input.Item.deltaToken).toBe("delta-token-1");
+
+    // Check SQS ingest message
+    expect(mockSqsSend).toHaveBeenCalledTimes(1);
+    const sqsCommand = mockSqsSend.mock.calls[0][0] as {
+      input: { QueueUrl: string; MessageBody: string };
+    };
+    expect(sqsCommand.input.QueueUrl).toBe(
+      "https://sqs.eu-west-2.amazonaws.com/123456789/petroglyph-ingest-test",
+    );
+    const sqsMessage = JSON.parse(sqsCommand.input.MessageBody) as { [key: string]: unknown };
+    expect(sqsMessage).toEqual({
+      fileId: "pdf-1",
+      profileId: "default",
+      itemMetadata: {
+        id: "pdf-1",
+        odataType: "#microsoft.graph.driveItem",
+        name: "notes.pdf",
+        webUrl: undefined,
+        resource: "me/drive/items/pdf-1",
+        parentReference: undefined,
+      },
+    });
   });
 
   it("continues an incremental sync from the stored delta token across pages", async () => {
@@ -303,6 +343,24 @@ describe("POST /sync/run", () => {
     ];
     expect(deltaTokenCommand.input.TableName).toBe("petroglyph-delta-tokens-test");
     expect(deltaTokenCommand.input.Item.deltaToken).toBe("delta-token-2");
+
+    // Check SQS ingest messages (2 PDFs queued)
+    expect(mockSqsSend).toHaveBeenCalledTimes(2);
+    const sqsFileIds = mockSqsSend.mock.calls.map(
+      (call) =>
+        (JSON.parse((call[0] as { input: { MessageBody: string } }).input.MessageBody) as {
+          fileId: string;
+        }).fileId,
+    );
+    expect(sqsFileIds).toEqual(["pdf-2", "pdf-3"]);
+
+    const firstSqsMessage = JSON.parse(
+      (mockSqsSend.mock.calls[0][0] as { input: { MessageBody: string } }).input.MessageBody,
+    ) as { [key: string]: unknown };
+    expect(firstSqsMessage.itemMetadata).toMatchObject({
+      id: "pdf-2",
+      resource: "me/drive/items/pdf-2",
+    });
   });
 
   it("returns queued=0 when the delta query contains no new PDF items", async () => {
@@ -347,6 +405,9 @@ describe("POST /sync/run", () => {
     expect(deltaTokenCommand.input.TableName).toBe("petroglyph-delta-tokens-test");
     expect(deltaTokenCommand.input.Item.profileId).toBe("default");
     expect(deltaTokenCommand.input.Item.deltaToken).toBe("delta-token-3");
+
+    // No SQS messages should be sent when nothing is queued
+    expect(mockSqsSend).not.toHaveBeenCalled();
   });
 
   it("refreshes an expiring access token before querying Graph", async () => {

--- a/packages/api/src/sync-run.test.ts
+++ b/packages/api/src/sync-run.test.ts
@@ -230,13 +230,15 @@ describe("POST /sync/run", () => {
 
     // Check SQS ingest message
     expect(mockSqsSend).toHaveBeenCalledTimes(1);
-    const sqsCommand = mockSqsSend.mock.calls[0][0] as {
+    const sqsCall = mockSqsSend.mock.calls[0];
+    expect(sqsCall).toBeDefined();
+    const sqsInput = sqsCall![0] as {
       input: { QueueUrl: string; MessageBody: string };
     };
-    expect(sqsCommand.input.QueueUrl).toBe(
+    expect(sqsInput.input.QueueUrl).toBe(
       "https://sqs.eu-west-2.amazonaws.com/123456789/petroglyph-ingest-test",
     );
-    const sqsMessage = JSON.parse(sqsCommand.input.MessageBody) as { [key: string]: unknown };
+    const sqsMessage = JSON.parse(sqsInput.input.MessageBody) as { [key: string]: unknown };
     expect(sqsMessage).toEqual({
       fileId: "pdf-1",
       profileId: "default",
@@ -348,16 +350,21 @@ describe("POST /sync/run", () => {
     expect(mockSqsSend).toHaveBeenCalledTimes(2);
     const sqsFileIds = mockSqsSend.mock.calls.map(
       (call) =>
-        (JSON.parse((call[0] as { input: { MessageBody: string } }).input.MessageBody) as {
-          fileId: string;
-        }).fileId,
+        (
+          JSON.parse((call[0] as { input: { MessageBody: string } }).input.MessageBody) as {
+            fileId: string;
+          }
+        ).fileId,
     );
     expect(sqsFileIds).toEqual(["pdf-2", "pdf-3"]);
 
+    const sqsCall2 = mockSqsSend.mock.calls[0];
+    expect(sqsCall2).toBeDefined();
+    expect(sqsCall2![0]).toBeDefined();
     const firstSqsMessage = JSON.parse(
-      (mockSqsSend.mock.calls[0][0] as { input: { MessageBody: string } }).input.MessageBody,
+      (sqsCall2![0] as { input: { MessageBody: string } }).input.MessageBody,
     ) as { [key: string]: unknown };
-    expect(firstSqsMessage.itemMetadata).toMatchObject({
+    expect(firstSqsMessage["itemMetadata"]).toMatchObject({
       id: "pdf-2",
       resource: "me/drive/items/pdf-2",
     });

--- a/packages/api/src/sync-run.test.ts
+++ b/packages/api/src/sync-run.test.ts
@@ -230,15 +230,18 @@ describe("POST /sync/run", () => {
 
     // Check SQS ingest message
     expect(mockSqsSend).toHaveBeenCalledTimes(1);
-    const sqsCall = mockSqsSend.mock.calls[0];
+    const sqsCall: unknown = mockSqsSend.mock.calls[0];
     expect(sqsCall).toBeDefined();
-    const sqsInput = sqsCall![0] as {
-      input: { QueueUrl: string; MessageBody: string };
-    };
-    expect(sqsInput.input.QueueUrl).toBe(
+    const sqsCommand = sqsCall as [
+      {
+        input: { QueueUrl: string; MessageBody: string };
+      },
+    ];
+    const sqsInput = sqsCommand[0].input;
+    expect(sqsInput.QueueUrl).toBe(
       "https://sqs.eu-west-2.amazonaws.com/123456789/petroglyph-ingest-test",
     );
-    const sqsMessage = JSON.parse(sqsInput.input.MessageBody) as { [key: string]: unknown };
+    const sqsMessage = JSON.parse(sqsInput.MessageBody) as { [key: string]: unknown };
     expect(sqsMessage).toEqual({
       fileId: "pdf-1",
       profileId: "default",
@@ -358,12 +361,16 @@ describe("POST /sync/run", () => {
     );
     expect(sqsFileIds).toEqual(["pdf-2", "pdf-3"]);
 
-    const sqsCall2 = mockSqsSend.mock.calls[0];
+    const sqsCall2: unknown = mockSqsSend.mock.calls[0];
     expect(sqsCall2).toBeDefined();
-    expect(sqsCall2![0]).toBeDefined();
-    const firstSqsMessage = JSON.parse(
-      (sqsCall2![0] as { input: { MessageBody: string } }).input.MessageBody,
-    ) as { [key: string]: unknown };
+    const sqsCommand2 = sqsCall2 as [
+      {
+        input: { MessageBody: string };
+      },
+    ];
+    const firstSqsMessage = JSON.parse(sqsCommand2[0].input.MessageBody) as {
+      [key: string]: unknown;
+    };
     expect(firstSqsMessage["itemMetadata"]).toMatchObject({
       id: "pdf-2",
       resource: "me/drive/items/pdf-2",

--- a/packages/api/src/sync-run.ts
+++ b/packages/api/src/sync-run.ts
@@ -19,8 +19,8 @@ interface GraphDriveFileItem {
   id: string;
   name: string;
   odataType: string;
-  webUrl?: string;
-  parentReference?: { driveId: string; path: string };
+  webUrl: string | undefined;
+  parentReference: { driveId: string; path: string } | undefined;
 }
 
 interface UnknownRecord {

--- a/packages/api/src/sync-run.ts
+++ b/packages/api/src/sync-run.ts
@@ -1,3 +1,4 @@
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 import { PutCommand, GetCommand } from "@aws-sdk/lib-dynamodb";
 import type { Context } from "hono";
 import { listProfiles } from "@petroglyph/core";
@@ -17,11 +18,24 @@ interface GraphDeltaPage {
 interface GraphDriveFileItem {
   id: string;
   name: string;
+  odataType: string;
+  webUrl?: string;
+  parentReference?: { driveId: string; path: string };
 }
 
 interface UnknownRecord {
   [key: string]: unknown;
 }
+
+function ingestQueueUrl(): string {
+  const url = process.env["INGEST_QUEUE_URL"];
+  if (!url) {
+    throw new Error("INGEST_QUEUE_URL env var not set");
+  }
+  return url;
+}
+
+const sqsClient = new SQSClient({});
 
 function fileRecordsTableName(): string {
   return process.env["FILE_RECORDS_TABLE"] ?? "petroglyph-file-records-default";
@@ -118,9 +132,28 @@ function parseGraphDriveFileItem(value: unknown): GraphDriveFileItem | null {
     return null;
   }
 
+  const odataType =
+    typeof value["@odata.type"] === "string" ? value["@odata.type"] : "#microsoft.graph.driveItem";
+  const webUrl = typeof value["webUrl"] === "string" ? value["webUrl"] : undefined;
+  const parentReference = isRecord(value["parentReference"])
+    ? {
+        driveId:
+          typeof value["parentReference"]["driveId"] === "string"
+            ? value["parentReference"]["driveId"]
+            : "",
+        path:
+          typeof value["parentReference"]["path"] === "string"
+            ? value["parentReference"]["path"]
+            : "",
+      }
+    : undefined;
+
   return {
     id: value["id"],
     name: filename,
+    odataType,
+    webUrl,
+    parentReference,
   };
 }
 
@@ -160,6 +193,28 @@ async function writeFileRecord(
         createdAt,
         status: "pending",
       },
+    }),
+  );
+}
+
+async function sendIngestMessage(file: GraphDriveFileItem, profileId: string): Promise<void> {
+  const message = {
+    fileId: file.id,
+    profileId,
+    itemMetadata: {
+      id: file.id,
+      odataType: file.odataType,
+      name: file.name,
+      webUrl: file.webUrl,
+      resource: `me/drive/items/${file.id}`,
+      parentReference: file.parentReference,
+    },
+  };
+
+  await sqsClient.send(
+    new SendMessageCommand({
+      QueueUrl: ingestQueueUrl(),
+      MessageBody: JSON.stringify(message),
     }),
   );
 }
@@ -210,6 +265,7 @@ export async function handleSyncRun(c: Context): Promise<Response> {
       }
 
       await writeFileRecord(file, createdAt, activeProfile.profileId);
+      await sendIngestMessage(file, activeProfile.profileId);
       queued += 1;
     }
 

--- a/packages/infra/iam.tf
+++ b/packages/infra/iam.tf
@@ -74,6 +74,12 @@ resource "aws_iam_role_policy" "petroglyph_api_policy" {
         ]
       },
       {
+        Sid      = "SQSSendIngestMessage"
+        Effect   = "Allow"
+        Action   = "sqs:SendMessage"
+        Resource = aws_sqs_queue.ingest.arn
+      },
+      {
         Sid    = "SSMGetParameter"
         Effect = "Allow"
         Action = ["ssm:GetParameter", "ssm:GetParameters"]

--- a/packages/infra/lambda_api.tf
+++ b/packages/infra/lambda_api.tf
@@ -37,6 +37,7 @@ resource "aws_lambda_function" "petroglyph_api" {
       FILE_RECORDS_TABLE             = aws_dynamodb_table.file_records.name
       DELTA_TOKENS_TABLE             = aws_dynamodb_table.delta_tokens.name
       STAGED_PDFS_BUCKET             = aws_s3_bucket.staged_pdfs.id
+      INGEST_QUEUE_URL               = aws_sqs_queue.ingest.url
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1024.0
         version: 3.1029.0
+      '@aws-sdk/client-sqs':
+        specifier: ^3.1029.0
+        version: 3.1029.0
       '@aws-sdk/client-ssm':
         specifier: ^3.1024.0
         version: 3.1024.0


### PR DESCRIPTION
## Description
Sync-run handler discovers files via Graph delta but never pushes messages to the ingest SQS queue. The processor is event-driven off SQS, so those files never get staged to S3.

## Changes
- Add sqs:SendMessage IAM permission to API Lambda role
- Wire INGEST_QUEUE_URL env var from Terraform
- Send SQS messages matching ingestQueueMessageSchema after writeFileRecord
- Extend delta item parsing to capture @odata.type, webUrl, parentReference
- Fix readFileRecordPage to use actual profileId

## Verification
- 190/190 API tests pass
- Lint clean
- IAM and Terraform correct