### PR TITLE
fix(sync-worker): validate SQS message shape before handling

### DIFF
--- a/packages/sync-worker/src/index.test.ts
+++ b/packages/sync-worker/src/index.test.ts
@@ -351,6 +351,56 @@ describe("sync-worker handler", () => {
     expect(url).toContain("token=existing-delta-token");
   });
 
+  it("rejects a message missing required fields without touching the job table", async () => {
+    mockDocSend.mockResolvedValue({});
+    mockSqsSend.mockResolvedValue({});
+
+    const event = makeEvent({
+      profileId: "profile-456",
+      sourceFolderPath: "OnyxBoox",
+      userId: "user-42",
+    });
+
+    const result = await handler(event);
+
+    expect(result.batchItemFailures).toHaveLength(1);
+    expect(result.batchItemFailures[0]?.itemIdentifier).toBe("message-123");
+
+    // An unvalidated jobId must never be used to write job status.
+    const jobStatusUpdates = mockDocSend.mock.calls.filter(
+      ([command]) =>
+        command instanceof UpdateCommand && command.input.TableName === "petroglyph-sync-jobs-test",
+    );
+    expect(jobStatusUpdates).toHaveLength(0);
+
+    // No ingest work should happen for a malformed message.
+    expect(mockSqsSend).not.toHaveBeenCalled();
+  });
+
+  it("rejects a message with wrong-typed fields before acting on it", async () => {
+    mockDocSend.mockResolvedValue({});
+    mockSqsSend.mockResolvedValue({});
+
+    const event = makeEvent({
+      jobId: 123,
+      profileId: "profile-456",
+      sourceFolderPath: "OnyxBoox",
+      userId: "user-42",
+    });
+
+    const result = await handler(event);
+
+    expect(result.batchItemFailures).toHaveLength(1);
+    expect(result.batchItemFailures[0]?.itemIdentifier).toBe("message-123");
+
+    const jobStatusUpdates = mockDocSend.mock.calls.filter(
+      ([command]) =>
+        command instanceof UpdateCommand && command.input.TableName === "petroglyph-sync-jobs-test",
+    );
+    expect(jobStatusUpdates).toHaveLength(0);
+    expect(mockSqsSend).not.toHaveBeenCalled();
+  });
+
   it("handles multiple pages of delta results", async () => {
     mockDocSend.mockImplementation((command: unknown) => {
       if (command instanceof GetCommand) {

--- a/packages/sync-worker/src/index.ts
+++ b/packages/sync-worker/src/index.ts
@@ -1,6 +1,7 @@
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 import { GetCommand, PutCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { SQSBatchResponse, SQSEvent, SQSRecord } from "aws-lambda";
+import { z } from "zod";
 import { docClient } from "./db.js";
 
 const TEN_MINUTES_MS = 10 * 60 * 1000;
@@ -31,12 +32,14 @@ function refreshTokensTableName(): string {
   return process.env["REFRESH_TOKENS_TABLE"] ?? "petroglyph-refresh-tokens-default";
 }
 
-interface SyncJobMessage {
-  jobId: string;
-  profileId: string;
-  sourceFolderPath: string;
-  userId: string;
-}
+export const syncJobMessageSchema = z.object({
+  jobId: z.string().min(1),
+  profileId: z.string().min(1),
+  sourceFolderPath: z.string().min(1),
+  userId: z.string().min(1),
+});
+
+type SyncJobMessage = z.infer<typeof syncJobMessageSchema>;
 
 interface GraphDeltaPage {
   value: unknown[];
@@ -393,7 +396,7 @@ async function processSyncJob(message: SyncJobMessage): Promise<number> {
 }
 
 async function handleRecord(record: SQSRecord): Promise<void> {
-  const message = JSON.parse(record.body) as SyncJobMessage;
+  const message = syncJobMessageSchema.parse(JSON.parse(record.body) as unknown);
 
   try {
     const fileCount = await processSyncJob(message);


### PR DESCRIPTION
## Summary

PR #92 review feedback (petroglyph-cjy). `handleRecord` in `packages/sync-worker/src/index.ts` did `JSON.parse(record.body) as SyncJobMessage` — a raw cast with no validation. Now validates the message structure via a zod schema before acting on it.

## Changes

- `packages/sync-worker/src/index.ts`:
  - New `syncJobMessageSchema` (zod, four required string fields: jobId, profileId, sourceFolderPath, userId) mirroring the processor's `ingestQueueMessageSchema` pattern
  - `handleRecord` parses via `syncJobMessageSchema.parse(...)` — malformed messages throw before any side effect (no job-status write, no ingest work), routing to the existing error path (logged + batchItemFailure + DLQ)
- `packages/sync-worker/src/index.test.ts`: 2 new rejection-path tests (missing field, wrong-typed field — the original raw-cast hole)

## Verification

- 7/7 sync-worker tests, repo-wide build/test/typecheck/lint green
- Review: gitleaks clean; schema verified against the producer (`sendSyncJobMessage`) — all four fields always non-empty strings, happy path unchanged
- No doc changes needed (malformed→DLQ flow already covered by ARCHITECTURE.md async-dispatch narrative)

## Base-note for reviewer

This branch is based on `feature/petroglyph-m3a` (PR #92, open) because `packages/sync-worker/` only exists there. **Merge PR #92 first**: after it lands, this PR's diff reduces to the two sync-worker files above.

Petroglyph: petroglyph-cjy (part of epic petroglyph-a8y)
