### PR TITLE
feat(plugin): add reconnect banner styling and ship styles.css

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -150,7 +150,7 @@ A TypeScript plugin that runs inside Obsidian, responsible for pulling staged fi
 
 #### Build
 
-Obsidian requires plugins to be distributed as a single CJS file (`dist/main.js`) with `obsidian` left external — the runtime injects it. `tsc` alone cannot produce a bundle, so the build uses **esbuild** (`esbuild.config.mjs`). The dev script adds inline source maps; the production build omits them. `manifest.json` (required by Obsidian alongside `dist/main.js`) lives at the package root and declares the plugin id, name, version, and `minAppVersion`.
+Obsidian requires plugins to be distributed as a single CJS file (`dist/main.js`) with `obsidian` left external — the runtime injects it. `tsc` alone cannot produce a bundle, so the build uses **esbuild** (`esbuild.config.mjs`). The dev script adds inline source maps; the production build omits them. `manifest.json` (required by Obsidian alongside `dist/main.js`) lives at the package root and declares the plugin id, name, version, and `minAppVersion`. The build also copies `styles.css` into `dist/`, so the loadable plugin folder ships as `main.js` + `manifest.json` + `styles.css` (the latter styles plugin UI, e.g. the reconnect banner).
 
 #### Plugin Location
 

--- a/packages/plugin/esbuild.config.mjs
+++ b/packages/plugin/esbuild.config.mjs
@@ -1,14 +1,25 @@
+import { cpSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import esbuild from "esbuild";
 
 const dev = process.argv.includes("--dev");
+const packageRoot = dirname(fileURLToPath(import.meta.url));
 
 await esbuild.build({
-  entryPoints: ["src/main.ts"],
+  entryPoints: [join(packageRoot, "src/main.ts")],
   bundle: true,
   external: ["obsidian"],
   format: "cjs",
-  outfile: "dist/main.js",
+  outfile: join(packageRoot, "dist/main.js"),
   platform: "node",
   sourcemap: dev ? "inline" : false,
   logLevel: "info",
 });
+
+// Assemble the plugin folder Obsidian loads: main.js + manifest.json + styles.css.
+const distDir = join(packageRoot, "dist");
+mkdirSync(distDir, { recursive: true });
+for (const file of ["manifest.json", "styles.css"]) {
+  cpSync(join(packageRoot, file), join(distDir, file));
+}

--- a/packages/plugin/src/build-artifact.test.ts
+++ b/packages/plugin/src/build-artifact.test.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("plugin build artifact", () => {
+  it("assembles the Obsidian plugin folder (main.js, manifest.json, styles.css) in dist", () => {
+    execFileSync(process.execPath, ["esbuild.config.mjs"], {
+      cwd: packageRoot,
+      stdio: "pipe",
+    });
+
+    const dist = join(packageRoot, "dist");
+    expect(existsSync(join(dist, "main.js"))).toBe(true);
+    expect(existsSync(join(dist, "manifest.json"))).toBe(true);
+    expect(existsSync(join(dist, "styles.css"))).toBe(true);
+
+    const sourceCss = readFileSync(join(packageRoot, "styles.css"), "utf8");
+    expect(readFileSync(join(dist, "styles.css"), "utf8")).toBe(sourceCss);
+  });
+});

--- a/packages/plugin/styles.css
+++ b/packages/plugin/styles.css
@@ -1,0 +1,25 @@
+.petroglyph-onedrive-banner {
+  background-color: var(--background-modifier-error);
+  color: var(--text-on-accent);
+  padding: 12px 16px;
+  margin: 12px 0;
+  border-radius: 6px;
+  border-left: 4px solid var(--text-error);
+  font-weight: 500;
+}
+
+.petroglyph-onedrive-banner button {
+  margin-top: 8px;
+  margin-right: 8px;
+  background-color: var(--text-error);
+  color: var(--text-on-accent);
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.petroglyph-onedrive-banner button:hover {
+  background-color: var(--text-error-hover);
+}


### PR DESCRIPTION
## Summary

Adds styling for the OneDrive reconnect banner and fixes the plugin build so `styles.css` ships in the deployment artifact.

## Changes

- `packages/plugin/styles.css` (new): `.petroglyph-onedrive-banner` styling — error background, padding, border, and button styling using Obsidian theme variables (`--background-modifier-error`, `--text-error`, `--text-error-hover`, `--text-on-accent`) so it adapts to light/dark themes. Targets the banner markup in `settings.ts`.
- `packages/plugin/esbuild.config.mjs`: build now resolves paths from the package root and copies `manifest.json` + `styles.css` into `dist/` alongside `main.js` (both `build` and `dev` modes). Manifest `styles` field intentionally not added — Obsidian auto-loads `styles.css` from the plugin folder.
- `packages/plugin/src/build-artifact.test.ts` (new): TDD build-artifact test — runs the real build and asserts `dist/` contains `main.js` + `manifest.json` + `styles.css` (byte-identical to sources).
- `ARCHITECTURE.md`: Build section updated to reflect the plugin artifact contents.

## Verification

- Build: all 7 packages OK; `dist/` contains all three files (byte-identical)
- Tests: 324 passed (plugin 94/94 incl. new build-artifact test)
- Typecheck, lint, format:check — all clean
- Review: styling matches markup, gitleaks clean, no material issues

Part of AC2 surfacing for petroglyph-9jt.8 (HITL).

Petroglyph: petroglyph-o2p
