### PR TITLE
test(api): use assertion matchers for sync dispatch queue tests

### DIFF
--- a/packages/api/src/sync-run.test.ts
+++ b/packages/api/src/sync-run.test.ts
@@ -1,3 +1,4 @@
+import type { SendMessageCommandInput } from "@aws-sdk/client-sqs";
 import { GetCommand, PutCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { exportSPKI, generateKeyPair, SignJWT } from "jose";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -173,7 +174,7 @@ describe("POST /sync/run", () => {
             sourceFolderPath: "OnyxBoox",
             userId: "user-42",
           }),
-        }),
+        }) as unknown as SendMessageCommandInput,
       }),
     );
   });

--- a/packages/api/src/sync-run.test.ts
+++ b/packages/api/src/sync-run.test.ts
@@ -163,24 +163,19 @@ describe("POST /sync/run", () => {
     const response = await postSyncRun();
     const { jobId } = (await response.json()) as { jobId: string };
 
-    expect(mockSqsSend).toHaveBeenCalledTimes(1);
-    const sqsCall = mockSqsSend.mock.calls[0];
-    expect(sqsCall).toBeDefined();
-    const sqsCommand = sqsCall as [{ input: { QueueUrl: string; MessageBody: string } }];
-    expect(sqsCommand[0].input.QueueUrl).toBe(
-      "https://sqs.eu-west-2.amazonaws.com/123456789/petroglyph-sync-jobs-test",
+    expect(mockSqsSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          QueueUrl: "https://sqs.eu-west-2.amazonaws.com/123456789/petroglyph-sync-jobs-test",
+          MessageBody: JSON.stringify({
+            jobId,
+            profileId: "default",
+            sourceFolderPath: "OnyxBoox",
+            userId: "user-42",
+          }),
+        }),
+      }),
     );
-
-    const messageBody = JSON.parse(sqsCommand[0].input.MessageBody) as {
-      jobId: string;
-      profileId: string;
-      sourceFolderPath: string;
-      userId: string;
-    };
-    expect(messageBody.jobId).toBe(jobId);
-    expect(messageBody.profileId).toBe("default");
-    expect(messageBody.sourceFolderPath).toBe("OnyxBoox");
-    expect(messageBody.userId).toBe("user-42");
   });
 
   it("does not perform the Graph delta walk", async () => {


### PR DESCRIPTION
## Summary

PR #92 self-review feedback (petroglyph-80h). Refactors `packages/api/src/sync-run.test.ts` to use assertion matchers instead of reaching into `mock.calls[]` and hard-casting, per two review comments.

## Changes

`packages/api/src/sync-run.test.ts` only (no production code):
- **Comment @169**: replaced `mockSqsSend.mock.calls[0]` reaching + unsafe cast with `expect(mockSqsSend).toHaveBeenCalledWith(expect.objectContaining({ input: expect.objectContaining({ QueueUrl, MessageBody }) }))`, typed via `as unknown as SendMessageCommandInput` (mirrors the repo idiom in `packages/plugin/src/main.test.ts`). Also dropped a redundant `toHaveBeenCalledTimes(1)`.
- **Comment @183**: replaced four one-by-one `messageBody.*` asserts with a single full-shape `MessageBody: JSON.stringify({ jobId, profileId, sourceFolderPath, userId })` expect (exact, byte-for-byte with production `sendSyncJobMessage` — also proves no extra fields).

## Verification

- sync-run.test 5/5; full api suite green
- `pnpm lint` clean across all 8 packages (an initial `no-unsafe-assignment` was caught in verify and fixed via `as unknown as SendMessageCommandInput` typing — commit f20a243)
- typecheck, format:check, build all green
- Review: matchers genuinely remove mock.calls[] coupling; no production code changed

## Base-note for reviewer

Based on `feature/petroglyph-m3a` (PR #92, open) because `packages/api/src/sync-run.test.ts` exists there. **Merge PR #92 first**; this PR then reduces to the single test file.

Petroglyph: petroglyph-80h (child of petroglyph-m3a / epic petroglyph-a8y)
